### PR TITLE
[SHOW] Add lambda function url to cdk

### DIFF
--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -33,4 +33,5 @@ new InfraStack(app, `PropertyTaxReliefStatusApi-${stage.stageName}`, {
   connectString: stage.connectString,
   credentialsName: stage.credentialsName,
   dbCredentialsSecretArn: stage.secretArn,
+  allowedOrigins: stage.allowedOrigins,
 });

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -17,6 +17,7 @@ export interface InfraStackProps extends StackProps {
   readonly connectString: string;
   readonly credentialsName: string;
   readonly dbCredentialsSecretArn: string;
+  readonly allowedOrigins: string[];
 }
 
 export class InfraStack extends Stack {
@@ -46,6 +47,26 @@ export class InfraStack extends Stack {
       },
       ...vpcConfig,
     });
+
+    this.lambdaFunction.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.AWS_IAM,
+      cors: { allowedOrigins: props.allowedOrigins },
+    });
+
+    const amplifyIamRole = new iam.Role(this, "amplifyIamRole", {
+      assumedBy: new iam.ServicePrincipal("amplify.amazonaws.com"),
+    });
+
+    amplifyIamRole.attachInlinePolicy(
+      new iam.Policy(this, "InvokeLambdaPolicy", {
+        statements: [
+          new iam.PolicyStatement({
+            actions: ["lambda:InvokeFunctionUrl"],
+            resources: [this.lambdaFunction.functionArn],
+          }),
+        ],
+      }),
+    );
 
     const customPolicy = new iam.Policy(this, "LambdaCustomPolicy", {
       statements: [

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -61,7 +61,7 @@ export class InfraStack extends Stack {
       new iam.Policy(this, "InvokeLambdaPolicy", {
         statements: [
           new iam.PolicyStatement({
-            actions: ["lambda:InvokeFunctionUrl"],
+            actions: ["lambda:InvokeFunctionUrl", "lambda:InvokeFunction"],
             resources: [this.lambdaFunction.functionArn],
           }),
         ],

--- a/infra/lib/stage-config.ts
+++ b/infra/lib/stage-config.ts
@@ -22,6 +22,9 @@ export interface StageConfig {
 
   /** The arn for the credentials secret in AWS Secrets Manager */
   readonly secretArn: string;
+
+  /** The CORS origins that are allowed to access the Lambda */
+  readonly allowedOrigins: string[];
 }
 
 /** Stage configurations keyed by stage name. */
@@ -34,6 +37,7 @@ export const STAGE_CONFIGURATIONS: Record<string, StageConfig> = {
     connectString: "TAX2_TAXU",
     credentialsName: "TAX2_CREDS_STAGING",
     secretArn: "arn:aws:secretsmanager:us-east-1:539590994798:secret:TAX2_CREDS_STAGING-eNohgJ",
+    allowedOrigins: ["*"],
   },
   prod: {
     stageName: "prod",
@@ -43,5 +47,6 @@ export const STAGE_CONFIGURATIONS: Record<string, StageConfig> = {
     connectString: "TAX2_PROD",
     credentialsName: "TAX2_CREDS_PROD",
     secretArn: "arn:aws:secretsmanager:us-east-1:973370773553:secret:TAX2_CREDS_PROD-GpFZD1",
+    allowedOrigins: ["https://propertytaxreliefstatus.nj.gov/"],
   },
 };

--- a/infra/lib/stage-config.ts
+++ b/infra/lib/stage-config.ts
@@ -37,7 +37,7 @@ export const STAGE_CONFIGURATIONS: Record<string, StageConfig> = {
     connectString: "TAX2_TAXU",
     credentialsName: "TAX2_CREDS_STAGING",
     secretArn: "arn:aws:secretsmanager:us-east-1:539590994798:secret:TAX2_CREDS_STAGING-eNohgJ",
-    allowedOrigins: ["*"],
+    allowedOrigins: ["https://amplifyapp.com"],
   },
   prod: {
     stageName: "prod",


### PR DESCRIPTION
## Link to ticket

This commit is part of resolving https://github.com/newjersey/tax-relief-status-checker/issues/31. Future PRs are as follows:
1. Make the Lambda API endpoint accessible [YOU ARE HERE]
2. Migrate to NextJS, use API Routes and SSR to hit Lambda API endpoint

## LLM Disclaimer
No LLM was used for this code

## What was done?
We need an API endpoint for our Lambda function. This commit utilizes Lambda Function URL functionality. This was chosen over API Gateway as it's simpler to set up and tear down, and allows us to test CORS and SSR without having to set up API Gateway.

This has been deployed to dev using `npx cdk deploy -c stage=dev` so we can test SSR in a subsequent commit

Notable requirements:
- implements CORS and IAM Auth.

## Accessibility
N/A

## Steps to test
N/A

## Screenshots (for visual changes)
N/A

## Notes