### PR TITLE
[ASK] Resolve accessibility issues

### DIFF
--- a/webapp/app/globals.css
+++ b/webapp/app/globals.css
@@ -17,3 +17,12 @@
 #beta-banner .usa-alert__text {
   max-width: fit-content;
 }
+
+.usa-prose > .usa-table-container--scrollable td {
+  white-space: wrap;
+}
+
+.usa-table-container--scrollable table {
+  table-layout: fixed;
+  width: 100%;
+}

--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import { Alert } from "@trussworks/react-uswds";
 import { NjHeader } from "@/components/NjHeader";
 import { NjFooter } from "@/components/NjFooter";
+import { StatusCheckerHeader } from "@/components/StatusCheckerHeader";
 import "@newjersey/njwds/dist/css/styles.css";
 import "./globals.css";
 
@@ -16,10 +16,7 @@ const RootLayout = ({ children }: { readonly children: React.ReactNode }) => (
   <html lang="en">
     <body>
       <NjHeader />
-      <Alert className="margin-0" id="beta-banner" type="info" noIcon={true} headingLevel="h1">
-        <strong>This tool is in beta.</strong> This means it is actively being worked on with new
-        features coming soon.
-      </Alert>
+      <StatusCheckerHeader />
       {children}
       <NjFooter />
     </body>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Label, Logo, TextInputMask, Form, Button } from "@trussworks/react-uswds";
+import { Label, TextInputMask, Form, Button } from "@trussworks/react-uswds";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { LandingPageFaq, expandFaqAccordionItem } from "@/components/LandingPageFaq";
@@ -120,18 +120,8 @@ const LandingPage = () => {
 
   return (
     <main id="main-content">
-      <section className="usa-section">
+      <section className="usa-section padding-top-2">
         <div className="grid-container">
-          <div className="tablet:grid-col-6">
-            <Logo
-              size="slim"
-              image={
-                <img src="/img/nj_taxation_logo.png" width={90} height={90} alt="Treasury logo" />
-              }
-            />
-            <h1 className="font-heading-2xl">Property Tax Relief Status Checker</h1>
-          </div>
-
           {apiError && (
             <div
               className="usa-alert usa-alert--error usa-alert--slim margin-bottom-3"
@@ -141,11 +131,13 @@ const LandingPage = () => {
             </div>
           )}
 
-          <div className="grid-row grid-gap margin-top-5 margin-bottom-10">
+          <div className="grid-row grid-gap margin-bottom-10">
             <div className="tablet:grid-col-6">
-              <h2>This website is checking your 2025 PAS&#8209;1 application status</h2>
+              <h1 className="font-heading-lg">
+                This website is checking your 2025 PAS&#8209;1 application status
+              </h1>
               <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full" noValidate>
-                <h3>Enter your SSN or ITN and Zip Code</h3>
+                <p className="text-bold font-heading-md">Enter your SSN or ITN and Zip Code</p>
                 <Label htmlFor="ssn" requiredMarker={true}>
                   Social Security or Individual Taxpayer Identification Number
                 </Label>
@@ -153,10 +145,12 @@ const LandingPage = () => {
                   <TextInputMask
                     id="ssn"
                     type="text"
+                    autoComplete=""
                     mask="###-##-####"
                     pattern="\d{3}-\d{2}-\d{4}"
                     required={true}
                     aria-invalid={errors.ssn ? "true" : "false"}
+                    aria-describedby={errors.ssn ? "ssnErrorMessage" : undefined}
                     {...register("ssn", {
                       required: "This question is required",
                       pattern: {
@@ -179,10 +173,12 @@ const LandingPage = () => {
                   <TextInputMask
                     id="zipCode"
                     type="text"
+                    autoComplete="postal-code"
                     mask="#####"
                     pattern="\d{5}"
                     required={true}
                     aria-invalid={errors.zipCode ? "true" : "false"}
+                    aria-describedby={errors.zipCode ? "zipCodeErrorMessage" : undefined}
                     {...register("zipCode", {
                       required: "This question is required",
                       minLength: {
@@ -215,6 +211,9 @@ const LandingPage = () => {
           </div>
         </div>
       </section>
+      <div className="grid-container usa-footer__return-to-top">
+        <a href="#nj-header">Return to top</a>
+      </div>
     </main>
   );
 };

--- a/webapp/app/status/page.tsx
+++ b/webapp/app/status/page.tsx
@@ -33,24 +33,6 @@ const StatusPage = async ({ searchParams }: StatusPageProps) => {
             </Link>
           </div>
           <div>
-            <div>
-              <Logo
-                size="slim"
-                image={
-                  <img
-                    src="/img/nj_taxation_logo.png"
-                    width={100}
-                    height={100}
-                    alt="Treasury logo"
-                  />
-                }
-              />
-              <h1 className="font-heading-3xl">
-                Property Tax Relief
-                <br />
-                Status Checker
-              </h1>
-            </div>
             <div className="grid-row">
               <div className="tablet:grid-col-3">
                 <p>

--- a/webapp/components/LandingPageFaq.tsx
+++ b/webapp/components/LandingPageFaq.tsx
@@ -1,4 +1,4 @@
-import { Accordion, type HeadingLevel, type AccordionProps } from "@trussworks/react-uswds";
+import { Accordion, type HeadingLevel, type AccordionProps, Table } from "@trussworks/react-uswds";
 
 export const expandFaqAccordionItem = (itemId: string) => {
   const button = document.querySelector<HTMLButtonElement>(`button[aria-controls="${itemId}"]`);
@@ -101,13 +101,13 @@ export const LandingPageFaq = (props: LandingPageFaqProps) => {
             payment(s) from each program. Your payment will be delayed if there is an issue with
             your application, or if we need additional information from you.
           </p>
-          <table className="usa-table">
+          <Table className="usa-table" bordered={true} scrollable={true}>
             <thead>
               <tr>
-                <th>Month</th>
-                <th>Senior Freeze</th>
-                <th>ANCHOR</th>
-                <th>Stay NJ</th>
+                <th className="width-card">Month</th>
+                <th className="width-mobile">Senior Freeze</th>
+                <th className="width-mobile">ANCHOR</th>
+                <th className="width-mobile">Stay NJ</th>
               </tr>
             </thead>
             <tbody>
@@ -164,7 +164,7 @@ export const LandingPageFaq = (props: LandingPageFaqProps) => {
                 <td></td>
               </tr>
             </tbody>
-          </table>
+          </Table>
         </>
       ),
       expanded: false,

--- a/webapp/components/NjFooter.tsx
+++ b/webapp/components/NjFooter.tsx
@@ -3,15 +3,12 @@ import { Logo } from "@trussworks/react-uswds";
 /** Site-wide footer with Division of Taxation contact info and NJ links. */
 export const NjFooter = () => (
   <footer className="usa-footer">
-    <div className="grid-container usa-footer__return-to-top">
-      <a href="#nj-header">Return to top</a>
-    </div>
     <div className="footer-social padding-5" style={{ backgroundColor: "#E5C53C" }}>
       <div className="grid-container">
         <div className="grid-row">
           <div className="usa-footer__logo grid-row mobile-lg:grid-col-6 mobile-lg:grid-gap-2">
             <div className="mobile-lg:grid-col-auto">
-              <h2 className="usa-footer__logo-heading">
+              <p className="usa-footer__logo-heading">
                 <a
                   href="https://www.nj.gov/treasury/taxation/"
                   target="_blank"
@@ -20,7 +17,7 @@ export const NjFooter = () => (
                 >
                   Division of Taxation
                 </a>
-              </h2>
+              </p>
             </div>
           </div>
           <div className="mobile-lg:grid-col-6 grid-col">

--- a/webapp/components/NjHeader.tsx
+++ b/webapp/components/NjHeader.tsx
@@ -10,7 +10,7 @@ export const NjHeader = () => (
     <a className="usa-skipnav" href="#main-content">
       Skip to main content
     </a>
-    <header className="nj-banner" aria-label="Official government website" id="nj-header">
+    <section className="nj-banner" aria-label="Official government website" id="nj-header">
       <div className="nj-banner__header">
         <div className="grid-container">
           <div className="nj-banner__inner">
@@ -37,6 +37,6 @@ export const NjHeader = () => (
           </div>
         </div>
       </div>
-    </header>
+    </section>
   </>
 );

--- a/webapp/components/StatusCheckerHeader.tsx
+++ b/webapp/components/StatusCheckerHeader.tsx
@@ -1,0 +1,27 @@
+import { Logo } from "@trussworks/react-uswds";
+import { Alert } from "@trussworks/react-uswds";
+
+/** Property Tax Relief Status Checker and logo */
+export const StatusCheckerHeader = () => (
+  <>
+    <header>
+      <Alert className="margin-0" id="beta-banner" type="info" noIcon={true} headingLevel="h1">
+        <strong>This tool is in beta.</strong> This means it is actively being worked on with new
+        features coming soon.
+      </Alert>
+      <div className="grid-container">
+        <div className="tablet:grid-col-6 padding-top-8">
+          <Logo
+            size="slim"
+            image={
+              <img src="/img/nj_taxation_logo.png" width={90} height={90} alt="Treasury logo" />
+            }
+          />
+          <p className="font-heading-2xl text-bold line-height-sans-1">
+            Property Tax Relief Status Checker
+          </p>
+        </div>
+      </div>
+    </header>
+  </>
+);

--- a/webapp/next-env.d.ts
+++ b/webapp/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Link to ticket

This commit resolves [77-Review accessibility](https://github.com/newjersey/tax-relief-status-checker/issues/77)

## LLM Disclaimer

- No LLM was used.

## What was done?
Update site to match Figma (a11y review done by @andrew-wc here: https://www.figma.com/design/fc59D8BV14x7EhW79ued5f/PAS-1-status-checker?node-id=450-7916&t=e9cIK6pVOGctbvqC-1)

- Changed the NJ-banner at the top from a header tag to section tag
- Created a new component to act as the header, and move the logo, page heading, and alert into the component and replaced it in the layout. 
- Moved the "Return to Top" button from footer into main
- Changed "This tool is for checking ..." to an h1
- "Property Tax Relief Status Checker" is now a p tag

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test


## Screenshots (for visual changes)


## Notes
- Horizontal table to be discussed with @andrew-wc later this morning, explicitly left out of this PR for now.
