### PR TITLE
[SHOW] - Update Content Changes

### DIFF
--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -146,9 +146,9 @@ const LandingPage = () => {
             <div className="tablet:grid-col-6">
               <h2>This tool is for checking your 2025 PAS-1 application status</h2>
               <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full" noValidate>
-                <h3>Enter your Social Security Number (SSN) and Zip Code</h3>
+                <h3>Enter your SSN or ITN and Zip Code</h3>
                 <Label htmlFor="ssn" requiredMarker={true}>
-                  SSN or Individual Taxpayer Identification Number (ITIN)
+                  Social Security or Individual Taxpayer Identification Number
                 </Label>
                 <div className="tablet:grid-col-10">
                   <TextInputMask
@@ -162,7 +162,7 @@ const LandingPage = () => {
                       required: "This question is required",
                       pattern: {
                         value: /\d{3}-\d{2}-\d{4}/,
-                        message: "Entered value does not match social security number format",
+                        message: "SSN or ITIN number entered must have nine digits",
                       },
                     })}
                   />
@@ -174,7 +174,7 @@ const LandingPage = () => {
                 </div>
 
                 <Label htmlFor="zipCode" requiredMarker={true}>
-                  Zip code you filed with
+                  Zip code you submitted with your application
                 </Label>
                 <div className="tablet:grid-col-10">
                   <TextInputMask

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -143,7 +143,7 @@ const LandingPage = () => {
 
           <div className="grid-row grid-gap margin-top-5 margin-bottom-10">
             <div className="tablet:grid-col-6">
-              <h2>This website is checking your 2025 PAS-1 application status</h2>
+              <h2>This website is checking your 2025 PAS&#8209;1 application status</h2>
               <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full" noValidate>
                 <h3>Enter your SSN or ITN and Zip Code</h3>
                 <Label htmlFor="ssn" requiredMarker={true}>

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -77,9 +77,9 @@ const LandingPage = () => {
                 application is different than the one you entered in this tool.
               </li>
               <li>
-                <strong>It's too soon</strong>: For online applications, it can take up to 3 weeks.
-                For paper applications, it can take up to 12 weeks. For ANCHOR-only applicants,
-                check back in the Fall.
+                <strong>It's too soon</strong>: For online applications, it can take up to 3 weeks
+                for an application to show up on this website. For paper applications, it can take
+                up to 12 weeks. For ANCHOR-only applicants, check back in the fall of 2026.
               </li>
             </ul>
             <p className="usa-alert__text">

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "next/navigation";
 import { Label, Logo, TextInputMask, Form, Button } from "@trussworks/react-uswds";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
-import { HorizontalDivider } from "@/components/HorizontalDivider";
 import { LandingPageFaq, expandFaqAccordionItem } from "@/components/LandingPageFaq";
 import { maskSsn } from "@/app/utils/maskSsn";
 import { formatDate } from "@/app/utils/formatDate";
@@ -144,7 +143,7 @@ const LandingPage = () => {
 
           <div className="grid-row grid-gap margin-top-5 margin-bottom-10">
             <div className="tablet:grid-col-6">
-              <h2>This tool is for checking your 2025 PAS-1 application status</h2>
+              <h2>This website is checking your 2025 PAS-1 application status</h2>
               <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full" noValidate>
                 <h3>Enter your SSN or ITN and Zip Code</h3>
                 <Label htmlFor="ssn" requiredMarker={true}>
@@ -210,7 +209,6 @@ const LandingPage = () => {
               </Form>
             </div>
           </div>
-          <HorizontalDivider />
           <div className="grid-row grid-gap margin-top-5">
             <h2 className="font-heading-l">Frequently Asked Questions (FAQs)</h2>
             <LandingPageFaq headingLevel="h3" />

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -84,7 +84,7 @@ const LandingPage = () => {
               </li>
             </ul>
             <p className="usa-alert__text">
-              For a full list of reasons, check out the{" "}
+              Find the{" "}
               <a
                 href="#faq_no_2025_application_found"
                 onClick={(e) => {
@@ -92,9 +92,9 @@ const LandingPage = () => {
                   expandFaqAccordionItem("faq_no_2025_application_found");
                 }}
               >
-                FAQ section
-              </a>
-              .
+                full list of other possible reasons
+              </a>{" "}
+              your application is not showing up
             </p>
           </>,
         );

--- a/webapp/app/status/page.tsx
+++ b/webapp/app/status/page.tsx
@@ -72,8 +72,8 @@ const StatusPage = async ({ searchParams }: StatusPageProps) => {
           <div className="margin-top-4">
             <p className="font-heading-xl">Your application was received on {applicationDate}.</p>
             <p>
-              Please allow time for your application to be reviewed. There's nothing you need to do
-              right now. If you applied early in the year, check back in early summer for an update.
+              Your application is being reviewed. No action is needed right now. If you applied
+              early this year, please check back in early summer.
             </p>
           </div>
         </div>

--- a/webapp/app/status/page.tsx
+++ b/webapp/app/status/page.tsx
@@ -70,7 +70,7 @@ const StatusPage = async ({ searchParams }: StatusPageProps) => {
             </div>
           </div>
           <div className="margin-top-4">
-            <p className="font-heading-xl">Your application was received on {applicationDate}.</p>
+            <p className="font-heading-xl">Your application was received on {applicationDate}</p>
             <p>
               Your application is being reviewed. No action is needed right now. If you applied
               early this year, please check back in early summer.

--- a/webapp/components/HorizontalDivider.tsx
+++ b/webapp/components/HorizontalDivider.tsx
@@ -1,2 +1,0 @@
-/** A simple horizontal rule divider. */
-export const HorizontalDivider = () => <div className="horizontal-divider" />;

--- a/webapp/components/LandingPageFaq.tsx
+++ b/webapp/components/LandingPageFaq.tsx
@@ -20,7 +20,7 @@ interface LandingPageFaqProps {
 export const LandingPageFaq = (props: LandingPageFaqProps) => {
   const faqContent: AccordionItemProps[] = [
     {
-      title: "When can I expect my paper application to show up in this online tool?",
+      title: "When can I expect my application to show up?",
       content: (
         <p>
           For online applications, it can take up to 3 weeks before a status shows up. For paper


### PR DESCRIPTION
## Link to ticket

This commit resolves [97](https://github.com/newjersey/tax-relief-status-checker/issues/97)

## LLM Disclaimer

- No LLM was used to write this code. 

## What was done?

- Changed the error message from "entered value does not match social security number format" to "SSN or ITIN number entered must have nine digits"
- Changed "zip code you filed with" to "zip code you submitted with your application"
- Changed FAQ title from "When can I expect my paper application to show up in this tool?" "When can I expect my application to show up?"
- Changed the Record found page to say "Your application is being reviewed. No action is needed right now. If you applied early this year, please check back in early summer"
- Changed heading from tool to website
- Changed the No 2025 Application Found page to match the content in the error message
- Deleted Horizontal Divider 
- Changed the '-' in PAS-1 to a '&#8209;' to prevent line breaking after a hyphen

## Accessibility

- [X] I have made sure this works with a screenreader!
- [X] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test


## Screenshots (for visual changes)

- Before

<img width="504" height="569" alt="Screenshot 2026-06-17 at 2 19 01 PM" src="https://github.com/user-attachments/assets/562c34ff-6128-4440-8dc8-1a21414617d8" />

<img width="742" height="281" alt="Screenshot 2026-06-17 at 2 19 15 PM" src="https://github.com/user-attachments/assets/82e62016-5fe7-4621-90ea-42a3b2b3f062" />

<img width="562" height="297" alt="Screenshot 2026-06-17 at 2 21 46 PM" src="https://github.com/user-attachments/assets/bd5b04d6-3f5d-47f6-807d-04636e4f520b" />


- After

<img width="431" height="432" alt="Screenshot 2026-06-17 at 2 14 55 PM" src="https://github.com/user-attachments/assets/ba4ea733-bfbf-495f-a72d-8ac62f6b4ea7" />

<img width="877" height="328" alt="Screenshot 2026-06-17 at 2 17 54 PM" src="https://github.com/user-attachments/assets/92da4c9e-1d2b-4533-a55d-58b56af4fe64" />

<img width="567" height="419" alt="Screenshot 2026-06-17 at 2 20 44 PM" src="https://github.com/user-attachments/assets/8ba78fc9-61f8-47ca-b37f-a3f9883c392c" />
## Notes


