### PR TITLE
[SHOW] Ensure error message is visible after submission

### DIFF
--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -22,6 +22,12 @@ interface StatusRecord {
   readonly application_date: string;
 }
 
+const returnToTop = () => {
+  const topOfPage = document.querySelector(`#nj-header`);
+  if (!topOfPage) return;
+  topOfPage.scrollIntoView({ behavior: "smooth", block: "start" });
+};
+
 const LandingPage = () => {
   const router = useRouter();
   const [apiError, setApiError] = useState<ReactNode | null>(null);
@@ -54,6 +60,7 @@ const LandingPage = () => {
             We are having an issue checking on your application status. Please try again later.
           </p>,
         );
+        returnToTop();
         return;
       }
 
@@ -97,6 +104,7 @@ const LandingPage = () => {
             </p>
           </>,
         );
+        returnToTop();
         return;
       }
 
@@ -115,6 +123,7 @@ const LandingPage = () => {
           We are having an issue checking on your application status. Please try again later.
         </p>,
       );
+      returnToTop();
     }
   };
 


### PR DESCRIPTION
## Link to ticket

No ticket.

## LLM Disclaimer

No

## What was done?

- Previously, if a user had scrolled down on the page and clicked submit, the error message would not be visible in the viewport. This commit forces the user to scroll to the top of the screen after pressing submit.

## Accessibility
- `tab_index` for the error message should be set to -1 from the [previous a11y commit](https://github.com/newjersey/tax-relief-status-checker/commit/f8bce7d1cf804513c9d9937b85a5c70f2ed2b558), bringing focus to screenreader users. This commit brings parity for sighted users.

## Steps to test

- Run locally, click submit, which fails with a 503 error on local. This should scroll to the top of the page

## Screenshots (for visual changes)

## Notes