### PR TITLE
Prefactor 116 - Switch from URL params to using React State

### DIFF
--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -6,6 +6,7 @@ import "@newjersey/njwds/dist/css/styles.css";
 import "./globals.css";
 import Script from "next/script";
 import { FeedbackWidget } from "@/components/FeedbackWidget";
+import { TaxReliefDataProvider } from "@/components/TaxReliefDataProvider";
 
 /** {@link https://nextjs.org/docs/app/api-reference/functions/generate-metadata} */
 export const metadata: Metadata = {
@@ -35,11 +36,13 @@ const RootLayout = ({ children }: { readonly children: React.ReactNode }) => (
       )}
     </head>
     <body>
-      <NjHeader />
-      <StatusCheckerHeader />
-      {children}
-      <FeedbackWidget />
-      <NjFooter />
+      <TaxReliefDataProvider>
+        <NjHeader />
+        <StatusCheckerHeader />
+        {children}
+        <FeedbackWidget />
+        <NjFooter />
+      </TaxReliefDataProvider>
     </body>
   </html>
 );

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -10,6 +10,7 @@ import { LandingPageFaq, expandFaqAccordionItem } from "@/components/LandingPage
 import { maskSsn } from "@/app/utils/maskSsn";
 import { formatDate } from "@/app/utils/formatDate";
 import { logGAEvent } from "./utils/analytics";
+import { useDataStore } from "@/components/TaxReliefDataProvider";
 
 /** Form data collected from the user. */
 interface UserData {
@@ -31,6 +32,7 @@ const returnToTop = () => {
 
 const LandingPage = () => {
   const router = useRouter();
+  const { setDataStore } = useDataStore();
   const [alertContent, setAlertContent] = useState<ReactNode | null>(null);
 
   const {
@@ -113,13 +115,14 @@ const LandingPage = () => {
 
       const lastFourSsnDigits = maskSsn(data.ssn);
       const formattedDate = formatDate(record2025.application_date);
-      const params = new URLSearchParams({
+      setDataStore({
         lastFourSsnDigits: lastFourSsnDigits,
         zipCode: data.zipCode,
-        date: formattedDate,
+        applicationDate: formattedDate,
       });
+
       logGAEvent(`api_200_record_found`);
-      router.push(`/status?${params.toString()}`);
+      router.push("/status");
     } catch {
       setAlertContent(
         <p className="usa-alert__text maxw-tablet">

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -118,7 +118,7 @@ const LandingPage = () => {
       setDataStore({
         lastFourSsnDigits: lastFourSsnDigits,
         zipCode: data.zipCode,
-        applicationDate: formattedDate,
+        applicationDateString: formattedDate,
       });
 
       logGAEvent(`api_200_record_found`);

--- a/webapp/app/status/page.tsx
+++ b/webapp/app/status/page.tsx
@@ -15,7 +15,13 @@ const StatusPage = () => {
     }
   }, [dataStore, router]);
 
-  const { lastFourSsnDigits, zipCode, applicationDate } = dataStore!;
+  // Next.js prerenders client components during the build,
+  // returning null here allows it to render only client-side
+  if (!dataStore) {
+    return null;
+  }
+
+  const { lastFourSsnDigits, zipCode, applicationDate } = dataStore;
 
   return (
     <main id="main-content">

--- a/webapp/app/status/page.tsx
+++ b/webapp/app/status/page.tsx
@@ -1,23 +1,21 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useDataStore } from "@/components/TaxReliefDataProvider";
 import Link from "next/link";
 
-interface StatusPageProps {
-  readonly searchParams: Promise<{
-    readonly lastFourSsnDigits?: string;
-    readonly zipCode?: string;
-    readonly date?: string;
-  }>;
-}
+const StatusPage = () => {
+  const router = useRouter();
+  const { dataStore } = useDataStore();
 
-const StatusPage = async ({ searchParams }: StatusPageProps) => {
-  const params = await searchParams;
-  const lastFourSsnDigits = params.lastFourSsnDigits;
-  const zipCode = params.zipCode;
-  const applicationDate = params.date;
+  useEffect(() => {
+    if (!dataStore) {
+      router.replace("/");
+    }
+  }, [dataStore, router]);
 
-  if (!lastFourSsnDigits || !applicationDate || !zipCode) {
-    redirect("/");
-  }
+  const { lastFourSsnDigits, zipCode, applicationDate } = dataStore!;
 
   return (
     <main id="main-content">

--- a/webapp/app/status/page.tsx
+++ b/webapp/app/status/page.tsx
@@ -21,7 +21,7 @@ const StatusPage = () => {
     return null;
   }
 
-  const { lastFourSsnDigits, zipCode, applicationDate } = dataStore;
+  const { lastFourSsnDigits, zipCode, applicationDateString } = dataStore;
 
   return (
     <main id="main-content">
@@ -55,7 +55,9 @@ const StatusPage = () => {
             </div>
           </div>
           <div className="margin-top-4">
-            <p className="font-heading-xl">Your application was received on {applicationDate}</p>
+            <p className="font-heading-xl">
+              Your application was received on {applicationDateString}
+            </p>
             <p>
               Your application is being reviewed. No action is needed right now. If you applied
               early this year, please check back in early summer.

--- a/webapp/components/TaxReliefDataProvider.tsx
+++ b/webapp/components/TaxReliefDataProvider.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+import type { ReactNode } from "react";
+
+export interface TaxReliefStatusData {
+  readonly lastFourSsnDigits: string;
+  readonly zipCode: string;
+  readonly applicationDate: string;
+}
+
+const TaxReliefData = createContext<{
+  dataStore: TaxReliefStatusData | null;
+  setDataStore: (data: TaxReliefStatusData | null) => void;
+} | null>(null);
+
+export const TaxReliefDataProvider = ({ children }: { children: ReactNode }) => {
+  const [dataStore, setDataStore] = useState<TaxReliefStatusData | null>(null);
+
+  return (
+    <TaxReliefData.Provider value={{ dataStore, setDataStore }}>{children}</TaxReliefData.Provider>
+  );
+};
+
+export const useDataStore = () => {
+  const context = useContext(TaxReliefData);
+  if (!context) {
+    throw new Error("useDataStore must be used within a TaxReliefDataProvider");
+  }
+  return context;
+};

--- a/webapp/components/TaxReliefDataProvider.tsx
+++ b/webapp/components/TaxReliefDataProvider.tsx
@@ -6,10 +6,10 @@ import type { ReactNode } from "react";
 export interface TaxReliefStatusData {
   readonly lastFourSsnDigits: string;
   readonly zipCode: string;
-  readonly applicationDate: string;
+  readonly applicationDateString: string;
 }
 
-const TaxReliefData = createContext<{
+const TaxReliefDataContext = createContext<{
   dataStore: TaxReliefStatusData | null;
   setDataStore: (data: TaxReliefStatusData | null) => void;
 } | null>(null);
@@ -18,14 +18,14 @@ export const TaxReliefDataProvider = ({ children }: { children: ReactNode }) => 
   const [dataStore, setDataStore] = useState<TaxReliefStatusData | null>(null);
 
   return (
-    <TaxReliefData.Provider value={{ dataStore, setDataStore }}>{children}</TaxReliefData.Provider>
+    <TaxReliefDataContext value={{ dataStore, setDataStore }}>{children}</TaxReliefDataContext>
   );
 };
 
 export const useDataStore = () => {
-  const context = useContext(TaxReliefData);
+  const context = useContext(TaxReliefDataContext);
   if (!context) {
-    throw new Error("useDataStore must be used within a TaxReliefDataProvider");
+    throw new Error("useDataStore must be used within a TaxReliefDataContext");
   }
   return context;
 };

--- a/webapp/next-env.d.ts
+++ b/webapp/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/webapp/next-env.d.ts
+++ b/webapp/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Link to ticket

This commit is a pre-factor before we implement https://github.com/newjersey/tax-relief-status-checker/issues/116

## LLM Disclaimer
An LLM created the first draft of this code, I worked on making it more readable and removing unnecessary types/code.

## What was done?

- Previously, we put state in the URL as params, this commit moves us to using React State with a [ContextProvider](https://react.dev/learn/passing-data-deeply-with-context), since future commits will fetch more complex data from the API.

## Accessibility
N/A, no visual changes

## Steps to test

- Run Cypress tests to make sure there is no regression to the user experience

## Screenshots (for visual changes)
N/A, no visual changes

## Notes
N/A
