### PR TITLE
[SHIP] 98 - change styling of beta banner

### DIFF
--- a/webapp/app/globals.css
+++ b/webapp/app/globals.css
@@ -18,6 +18,10 @@
   max-width: fit-content;
 }
 
+#beta-banner {
+  border-left-color: rgb(231, 246, 248);
+}
+
 .usa-prose > .usa-table-container--scrollable td {
   white-space: wrap;
 }


### PR DESCRIPTION
## Link to ticket

https://github.com/newjersey/tax-relief-status-checker/issues/98

## LLM Disclaimer

- No LLM was used

## What was done?

- Design requested that we change the visual styling of the USWDS Alert component which is used for the beta banner

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test

Run locally and verify that site looks correct

## Screenshots (for visual changes)

- Before
<img width="1144" height="125" alt="image" src="https://github.com/user-attachments/assets/6f2bd858-5623-4908-91bc-ebef40e0edfd" />

- After
<img width="1507" height="114" alt="image" src="https://github.com/user-attachments/assets/a86a8e08-87a6-4d83-a6d4-79893faa49db" />

## Notes

Any additional information about changes to approach or new patterns? Any future development
considerations or refactorings?
