### PR TITLE
Add attribute to Feedback Widget to have it publish to GA

### DIFF
--- a/webapp/components/FeedbackWidget.tsx
+++ b/webapp/components/FeedbackWidget.tsx
@@ -19,7 +19,10 @@ const FeedbackWidgetClientOnly = (): ReactElement => {
   return (
     <>
       <section aria-label="Leave Feedback">
-        <feedback-widget contact-link="https://www.nj.gov/treasury/taxation/contact.shtml?open=email"></feedback-widget>
+        <feedback-widget
+          contact-link="https://www.nj.gov/treasury/taxation/contact.shtml?open=email"
+          only-save-rating-to-analytics="true"
+        ></feedback-widget>
       </section>
     </>
   );


### PR DESCRIPTION
## Link to ticket

No Ticket

## LLM Disclaimer

- No LLM was used for this code

## What was done?

- Previously, feedback widget was publishing to the Innovation-owned Google Sheet, and required Looker dashboard to view this
- Since we already have a GA4 account for this project, we'd like it to publish to our GA4 account instead of Google Sheets

## Accessibility

N/A

## Steps to test

- Describe how a reviewer should test the changes, including:
  - Unit/integration/manual tests
  - Test data used
  - New migrations or libraries

## Screenshots (for visual changes)
N/A

## Notes

