### PR TITLE
[SHOW] - 116 - api explicitly check for payment sent trans code 

### DIFF
--- a/lambda/src/transaction.ts
+++ b/lambda/src/transaction.ts
@@ -19,8 +19,10 @@ export const buildTransaction = (
     status = "issue_flagged";
   } else if (TRANS_CDE === "RR" && TRANS_STATUS_CDE.startsWith("AP")) {
     status = "approved";
-  } else {
+  } else if (TRANS_CDE === "RF") {
     status = "payment_sent";
+  } else {
+    throw new Error(`Invalid TRANS_CDE: ${TRANS_CDE}`);
   }
 
   if (status === "issue_flagged") {

--- a/lambda/src/transaction.ts
+++ b/lambda/src/transaction.ts
@@ -30,21 +30,23 @@ export const buildTransaction = (
   }
 
   if (status === "payment_sent") {
-    let method;
-    if (CHECK_NUM.slice(1, 3) === "NN") {
-      method = "direct_deposit";
-    } else if (CHECK_NUM.slice(1, 3)) {
-      method = "check";
-    } else {
+    if (!CHECK_NUM) {
       throw new Error(`Missing CHECK_NUM`);
+    } else {
+      let method;
+      if (CHECK_NUM.slice(1, 3) === "NN") {
+        method = "direct_deposit";
+      } else {
+        method = "check";
+      }
+      const payment_details = {
+        amount: CHECK_AMT,
+        date: CHECK_DTE,
+        method: method,
+        check_number: CHECK_NUM,
+      };
+      return { status: status, payment_details: payment_details };
     }
-    const payment_details = {
-      amount: CHECK_AMT,
-      date: CHECK_DTE,
-      method: method,
-      check_number: CHECK_NUM,
-    };
-    return { status: status, payment_details: payment_details };
   }
   return { status: status };
 };

--- a/lambda/src/transactions.test.ts
+++ b/lambda/src/transactions.test.ts
@@ -73,6 +73,16 @@ describe("build transaction status codes", () => {
     });
   });
 
+  describe("when TRANS_X_CDE is missing", () => {
+    it("throws an error with trans cde", async () => {
+      const row = buildMockRow({
+        TRANS_1_CDE: null,
+      });
+
+      expect(() => callBuildTransaction(row, 1)).toThrow("Invalid TRANS_CDE: null");
+    });
+  });
+
   describe("when CHECK_X_NUMBER second + third characters are NOT NN", () => {
     it("returns payment method as check", async () => {
       const row = buildMockRow({

--- a/lambda/src/transactions.test.ts
+++ b/lambda/src/transactions.test.ts
@@ -111,7 +111,7 @@ describe("build transaction status codes", () => {
     it("throws an error for Missing CHECK_NUM", async () => {
       const row = buildMockRow({
         TRANS_1_CDE: "RF",
-        CHECK_1_NUM: "",
+        CHECK_1_NUM: null,
       });
 
       expect(() => callBuildTransaction(row, 1)).toThrow("Missing CHECK_NUM");


### PR DESCRIPTION
## Link to ticket

This commit resolves a part of [116](https://github.com/newjersey/tax-relief-status-checker/issues/116), 

## LLM Disclaimer

- No LLM was used to write code. 

## What was done?

- API now sets transaction status to `payment_sent` now iff the `TRANS_CDE === "RF"`, and throws an error otherwise. 
- This had to be done because while setting up alarms, we ran into errors in prod. The main cause appears to be that there were some transactions that were missing `CHECK_NUM`, but had a status code of `payment_sent`. This should not happen with our current design, and the previous implementation had mislabeled these transactions by defaulting the status code to `payment_sent`
- Changed missing `CHECK_NUM` error throw to be before string slice to prevent against reading on null

## Accessibility

-No accessibility changes

## Steps to test

- New unit test for when `TRANS_CDE` is missing or not one of `RR` or `RF`.

## Screenshots (for visual changes)

No visual changes

## Notes

