### PR TITLE
[SHOW] Fix bug where metric dimension uses lowercase s instead of uppercase

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -7,6 +7,8 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import * as cw from "aws-cdk-lib/aws-cloudwatch";
+import * as cwActions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as sns from "aws-cdk-lib/aws-sns";
 
 const DIRNAME = path.dirname(fileURLToPath(import.meta.url));
 const LAMBDA_TIMEOUT_SECONDS = 5;
@@ -28,11 +30,16 @@ export class InfraStack extends Stack {
   constructor(scope: Construct, id: string, props: InfraStackProps) {
     super(scope, id, props);
 
-    new cw.Alarm(this, "PropertyTaxReliefStatusApi500Alarm", {
+    const alarmNotificationTopic = new sns.Topic(this, "PropertyTaxReliefStatusApiAlarmTopic", {
+      topicName: `property-tax-relief-status-api-alarms-${props.stageName}`,
+      displayName: "Property Tax Relief Status API Alarms",
+    });
+
+    const api500Alarm = new cw.Alarm(this, "PropertyTaxReliefStatusApi500Alarm", {
       metric: new cw.Metric({
         namespace: "TaxReliefStatusApi",
         metricName: "ResponseCount",
-        dimensionsMap: { statusCode: "500" },
+        dimensionsMap: { StatusCode: "500" },
         statistic: "Sum",
       }),
       threshold: 0,
@@ -43,6 +50,8 @@ export class InfraStack extends Stack {
       comparisonOperator: cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
       treatMissingData: cw.TreatMissingData.NOT_BREACHING,
     });
+
+    api500Alarm.addAlarmAction(new cwActions.SnsAction(alarmNotificationTopic));
 
     const vpc = ec2.Vpc.fromLookup(this, `vpc-${props.stageName}`, {
       vpcId: props.vpcId,


### PR DESCRIPTION
## Link to ticket

No ticket exists for this Ops work

## LLM Disclaimer

- No LLM was used to write this code

## What was done?
- fixed bug where dimension filter was on `statusCode` and not `StatusCode`. This caused the alarm to not trigger when there were errors.
- Added SNS topic so we can manually subscribe innovation emails when appropriate (chose to do this manually to avoid checking these emails into version control)

## Accessibility
N/A

## Steps to test
- Synthesized this in `dev` and validated that the SNS topic was successfully created and that i could subscribe to this alarm

## Screenshots (for visual changes)
N/A

## Notes

