### PR TITLE
[SHOW] 153 - remove NEXT_PUBLIC_ENABLE_SHOW_PAYMENTS feature flag

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -23,5 +23,3 @@ jobs:
           build: npx next build
           start: npx next start
           wait-on: "http://localhost:3000/"
-        env:
-          NEXT_PUBLIC_ENABLE_SHOW_PAYMENTS: "true"

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -140,10 +140,7 @@ const LandingPage = () => {
       });
 
       logGAEvent(`api_200_record_found`);
-      if (
-        process.env.NEXT_PUBLIC_ENABLE_SHOW_PAYMENTS == "true" &&
-        hasPaymentSentTransaction(record2025)
-      ) {
+      if (hasPaymentSentTransaction(record2025)) {
         router.push("/payment-info");
       } else {
         router.push("/application-received");


### PR DESCRIPTION
## Link to ticket

https://github.com/newjersey/tax-relief-status-checker/issues/153

## LLM Disclaimer

- No LLM was used for this PR

## What was done?

- Previously, we gated routing users to the `payment-info` page behind a feature flag. Now that the July 15th launch date has passed, we no longer need to support this flag.

## Accessibility
N/A

## Steps to test
- Ran server locally WITHOUT feature flag using `npm run test`
- Ran Cypress against local server using `npm run cypress` from project root
- Validated that Cypress tests passed. (Using version from `main`, cypress tests would fail unless feature flag was set with `NEXT_PUBLIC_ENABLE_SHOW_PAYMENTS="true" npm run dev`)

## Screenshots (for visual changes)
None

## Notes

