### PR TITLE
[SHOW] - 160 added logging for a database row's DLN_NUM

### DIFF
--- a/lambda/src/helpers.ts
+++ b/lambda/src/helpers.ts
@@ -1,5 +1,6 @@
 //Only used in tests
 export const buildMockRow = (overrides = {}) => ({
+  DLN_NUM: "00000001",
   SOCIAL_SECURITY_NUMBER_IDN: "123456789",
   ZIP_ADR: "12345",
   RETURN_YEAR_DTE: 2025,

--- a/lambda/src/index.ts
+++ b/lambda/src/index.ts
@@ -96,6 +96,7 @@ const buildResponse = (rows: InquiryRow[]): BuildResponseResult => {
     return { records: [] };
   }
 
+  console.log(`DLN_NUM: ${rows[0].DLN_NUM}`);
   const records = rows.map(mapRowToRecord);
 
   return { records };

--- a/lambda/src/types.d.ts
+++ b/lambda/src/types.d.ts
@@ -22,5 +22,6 @@ export interface InquiryRow {
   readonly RNY_APPLIED_DTE: string;
   readonly RETURN_YEAR_DTE: number;
   readonly TRANS_TOTAL_NUM: number;
+  readonly DLN_NUM: string;
   readonly [key: string]: unknown;
 }


### PR DESCRIPTION
## Link to ticket

This commit resolves [160](https://github.com/newjersey/tax-relief-status-checker/issues/160)

## LLM Disclaimer

- No LLM was used for this code

## What was done?

- Added logging to lambda function during the building of a record response. Done so that after a record row is accessed, an engineer is able to see what DLN_NUM the row was associated with, allowing them to look up the exact record in the DB without having to log PII. 

## Steps to test

- Log onto dev amplify and test API response with 020383155 | 08884  as ssn | zip pair then go to cloudwatch to confirm `DLN_NUM: 13800674901` is in the logs. Test with any other ssn/zip pairs you have from test db.



