### PR TITLE
[SHOW] - Created Logout button component and moved into header

### DIFF
--- a/webapp/app/application-received/page.tsx
+++ b/webapp/app/application-received/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useDataStore } from "@/components/TaxReliefDataProvider";
-import Link from "next/link";
 import { ProcessList, ProcessListHeading, ProcessListItem } from "@trussworks/react-uswds";
 import { ApplicationReceivedFaqContent } from "./ApplicationReceivedFaqContent";
 import { FaqSection } from "@/components/FaqSection";
@@ -30,14 +29,6 @@ const ApplicationReceivedPage = () => {
     <main id="main-content">
       <section className="usa-section">
         <div className="grid-container">
-          <div style={{ textAlign: "right" }}>
-            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-                <use href="/img/sprite.svg#logout"></use>
-              </svg>
-              Log out
-            </Link>
-          </div>
           <div>
             <div className="grid-row">
               <div className="tablet:grid-col-3">

--- a/webapp/app/more-information-needed/page.tsx
+++ b/webapp/app/more-information-needed/page.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useDataStore } from "@/components/TaxReliefDataProvider";
 import { IssueFlaggedType } from "@/components/types";
-import Link from "next/link";
 import { Alert } from "@trussworks/react-uswds";
 
 const MoreInformationNeededPage = () => {
@@ -82,14 +81,6 @@ const MoreInformationNeededPage = () => {
     <main id="main-content">
       <section className="usa-section">
         <div className="grid-container">
-          <div style={{ textAlign: "right" }}>
-            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-                <use href="/img/sprite.svg#logout"></use>
-              </svg>
-              Log out
-            </Link>
-          </div>
           <div>
             <div className="grid-row">
               <div className="tablet:grid-col-3">

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -3,7 +3,6 @@
 import { JSX, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useDataStore } from "@/components/TaxReliefDataProvider";
-import Link from "next/link";
 import { Table } from "@trussworks/react-uswds";
 import { formatDate } from "../utils/formatDate";
 import { PaymentInfoFaqContent } from "@/app/payment-info/PaymentInfoFaqContent";
@@ -101,14 +100,6 @@ const PaymentInfoPage = () => {
     <main id="main-content">
       <section className="usa-section">
         <div className="grid-container">
-          <div style={{ textAlign: "right" }}>
-            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-                <use href="/img/sprite.svg#logout"></use>
-              </svg>
-              Log out
-            </Link>
-          </div>
           <div>
             <div className="grid-row">
               <div className="tablet:grid-col-3">

--- a/webapp/components/LogoutButton.tsx
+++ b/webapp/components/LogoutButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+
+const PAGES_WITH_LOGOUT = ["/more-information-needed", "/application-received", "/payment-info"];
+
+export const LogoutButton = () => {
+  const pathname = usePathname();
+
+  const shouldShowButton = PAGES_WITH_LOGOUT.includes(pathname);
+
+  if (!shouldShowButton) return null;
+
+  return (
+    <>
+      <div style={{ textAlign: "right" }}>
+        <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
+          <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
+            <use href="/img/sprite.svg#logout"></use>
+          </svg>
+          Log out
+        </Link>
+      </div>
+    </>
+  );
+};

--- a/webapp/components/LogoutButton.tsx
+++ b/webapp/components/LogoutButton.tsx
@@ -13,13 +13,15 @@ export const LogoutButton = () => {
 
   return (
     <>
-      <div style={{ textAlign: "right" }}>
-        <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-          <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-            <use href="/img/sprite.svg#logout"></use>
-          </svg>
-          Log out
-        </Link>
+      <div className="grid-container">
+        <div style={{ textAlign: "right" }}>
+          <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
+            <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
+              <use href="/img/sprite.svg#logout"></use>
+            </svg>
+            Log out
+          </Link>
+        </div>
       </div>
     </>
   );

--- a/webapp/components/LogoutButton.tsx
+++ b/webapp/components/LogoutButton.tsx
@@ -2,12 +2,12 @@
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 
-const PAGES_WITH_LOGOUT = ["/more-information-needed", "/application-received", "/payment-info"];
+const PAGES_WITHOUT_LOGOUT = ["/"];
 
 export const LogoutButton = () => {
   const pathname = usePathname();
 
-  const shouldShowButton = PAGES_WITH_LOGOUT.includes(pathname);
+  const shouldShowButton = !PAGES_WITHOUT_LOGOUT.includes(pathname);
 
   if (!shouldShowButton) return null;
 

--- a/webapp/components/StatusCheckerHeader.tsx
+++ b/webapp/components/StatusCheckerHeader.tsx
@@ -1,5 +1,6 @@
 import { Logo } from "@trussworks/react-uswds";
 import { Alert } from "@trussworks/react-uswds";
+import { LogoutButton } from "./LogoutButton";
 
 /** Property Tax Relief Status Checker and logo */
 export const StatusCheckerHeader = () => (
@@ -9,6 +10,7 @@ export const StatusCheckerHeader = () => (
         <strong>This website is in beta.</strong> This means it is actively being worked on with new
         features coming soon.
       </Alert>
+      <LogoutButton />
       <div className="grid-container">
         <div className="tablet:grid-col-6 padding-top-8">
           <Logo

--- a/webapp/cypress/e2e/landingPage.cy.ts
+++ b/webapp/cypress/e2e/landingPage.cy.ts
@@ -12,6 +12,10 @@ it("should allow the user to visit the webpage", () => {
   cy.contains("h1", "This website is checking your 2025 PAS");
 });
 
+it("should NOT have a logout button", () => {
+  cy.contains("a", "Log out").should("not.exist");
+});
+
 it("should display an error message when the user tries to submit empty fields", () => {
   cy.get(`button[type="submit"]`).click();
   const ssnError = cy.get(`span[id="ssnErrorMessage"]`);


### PR DESCRIPTION
## Link to ticket

This commit resolves [172](https://github.com/newjersey/tax-relief-status-checker/issues/172)

## LLM Disclaimer

- Used an LLM to figure out how to access pathname

## What was done?

- Created a `LogoutButton.tsx` component to remove logout button from each page besides landing and into layout
- `LogoutButton` renders conditionally based off pathname (only want it on /more-information-needed", "/application-received", "/payment-info)
- Moved `LogoutButton.tsx` component into `TaxStatusCheckerHeader.tsx` component to match its location in mocks

## Accessibility

- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test

- Manually test

## Screenshots (for visual changes)

- Before
<img width="740" height="771" alt="Screenshot 2026-08-13 at 4 24 55 PM" src="https://github.com/user-attachments/assets/28150453-23a4-417c-9c87-08396dbba34b" />

- After
<img width="823" height="752" alt="Screenshot 2026-08-13 at 4 26 41 PM" src="https://github.com/user-attachments/assets/004d3627-a17f-481d-bedd-796c2dc601c5" />

## Notes

Before merge - see if there is a way to remove raw styling `textAlign: right`: see https://github.com/newjersey/tax-relief-status-checker/pull/236#discussion_r3807816380
