### PR TITLE
214 - Add autofile anchor webpages

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -91,21 +91,6 @@ export class InfraStack extends Stack {
       assumedBy: new iam.ServicePrincipal("amplify.amazonaws.com"),
     });
 
-    amplifyIamRole.attachInlinePolicy(
-      new iam.Policy(this, "InvokeLambdaPolicy", {
-        statements: [
-          new iam.PolicyStatement({
-            actions: ["lambda:InvokeFunctionUrl", "lambda:InvokeFunction"],
-            resources: [this.lambdaFunction.functionArn],
-          }),
-          new iam.PolicyStatement({
-            actions: ["lambda:InvokeFunctionUrl", "lambda:InvokeFunction"],
-            resources: [this.autofileLambdaFunction.functionArn],
-          }),
-        ],
-      }),
-    );
-
     const customPolicy = new iam.Policy(this, "LambdaCustomPolicy", {
       statements: [
         new iam.PolicyStatement({
@@ -145,6 +130,17 @@ export class InfraStack extends Stack {
       authType: lambda.FunctionUrlAuthType.AWS_IAM,
       cors: { allowedOrigins: props.allowedOrigins },
     });
+
+    amplifyIamRole.attachInlinePolicy(
+      new iam.Policy(this, "InvokeLambdaPolicy", {
+        statements: [
+          new iam.PolicyStatement({
+            actions: ["lambda:InvokeFunctionUrl", "lambda:InvokeFunction"],
+            resources: [this.lambdaFunction.functionArn, this.autofileLambdaFunction.functionArn],
+          }),
+        ],
+      }),
+    );
   }
 
   private buildVpcConfig(

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -98,6 +98,10 @@ export class InfraStack extends Stack {
             actions: ["lambda:InvokeFunctionUrl", "lambda:InvokeFunction"],
             resources: [this.lambdaFunction.functionArn],
           }),
+          new iam.PolicyStatement({
+            actions: ["lambda:InvokeFunctionUrl", "lambda:InvokeFunction"],
+            resources: [this.autofileLambdaFunction.functionArn],
+          }),
         ],
       }),
     );

--- a/lambda-anchor-autofile-api/src/index.test.ts
+++ b/lambda-anchor-autofile-api/src/index.test.ts
@@ -35,6 +35,17 @@ describe("handler", () => {
       expect(result).toEqual({ error: "Request must include ssn (9 digits) and zip (5 digits)" });
     });
 
+    it("strips hyphens from SSN before validation", async () => {
+      dynamoMock.on(GetItemCommand).resolves({ Item: undefined });
+
+      const result = await handler({ ssn: "123-45-6789", zip: "07001" });
+
+      expect(result).toEqual({ autofilePlanned: false });
+      const expectedHash = computeSsnZipHash("123456789", "07001");
+      const call = dynamoMock.commandCalls(GetItemCommand)[0];
+      expect(call.args[0].input.Key).toEqual({ ssnZipHash: { S: expectedHash } });
+    });
+
     it("returns error for null event", async () => {
       const result = await handler(null);
 

--- a/lambda-anchor-autofile-api/src/index.test.ts
+++ b/lambda-anchor-autofile-api/src/index.test.ts
@@ -35,23 +35,6 @@ describe("handler", () => {
       expect(result).toEqual({ error: "Request must include ssn (9 digits) and zip (5 digits)" });
     });
 
-    it("strips hyphens from SSN before validation", async () => {
-      dynamoMock.on(GetItemCommand).resolves({ Item: undefined });
-
-      const result = await handler({ ssn: "123-45-6789", zip: "07001" });
-
-      expect(result).toEqual({ autofilePlanned: false });
-      const expectedHash = computeSsnZipHash("123456789", "07001");
-      const call = dynamoMock.commandCalls(GetItemCommand)[0];
-      expect(call.args[0].input.Key).toEqual({ ssnZipHash: { S: expectedHash } });
-    });
-
-    it("returns error for null event", async () => {
-      const result = await handler(null);
-
-      expect(result).toEqual({ error: "Request must include ssn (9 digits) and zip (5 digits)" });
-    });
-
     it("throws when TABLE_NAME is not configured", async () => {
       vi.stubEnv("TABLE_NAME", "");
 
@@ -69,7 +52,7 @@ describe("handler", () => {
 
       const result = await handler({ ssn: "123456789", zip: "07001" });
 
-      expect(result).toEqual({ autofilePlanned: true, paymentMethod: "CHECK" });
+      expect(result).toEqual({ autofilePlanned: true, paymentMethod: "check" });
     });
 
     it("returns autofilePlanned true with DIRECT_DEPOSIT when item has direct deposit", async () => {
@@ -79,7 +62,7 @@ describe("handler", () => {
 
       const result = await handler({ ssn: "123456789", zip: "07001" });
 
-      expect(result).toEqual({ autofilePlanned: true, paymentMethod: "DIRECT_DEPOSIT" });
+      expect(result).toEqual({ autofilePlanned: true, paymentMethod: "direct_deposit" });
     });
 
     it("returns autofilePlanned false when item does not exist", async () => {

--- a/lambda-anchor-autofile-api/src/index.ts
+++ b/lambda-anchor-autofile-api/src/index.ts
@@ -1,9 +1,9 @@
 import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
 import { computeSsnZipHash } from "./util/computeSsnZipHash";
 
-enum PaymentMenthod {
-  Check = "CHECK",
-  DirectDeposit = "DIRECT_DEPOSIT",
+enum PaymentMethod {
+  Check = "check",
+  DirectDeposit = "direct_deposit",
 }
 
 export interface AutofileLookupRequest {
@@ -14,7 +14,7 @@ export interface AutofileLookupRequest {
 export interface AutofileLookupResponse {
   /** Whether the SSN/ZIP pair is planned for ANCHOR autofile. */
   readonly autofilePlanned: boolean;
-  readonly paymentMethod?: PaymentMenthod;
+  readonly paymentMethod?: PaymentMethod;
 }
 
 const dynamoClient = new DynamoDBClient({});
@@ -69,6 +69,6 @@ export const handler = async (
 
   return {
     autofilePlanned: true,
-    paymentMethod: isDirectDeposit ? PaymentMenthod.DirectDeposit : PaymentMenthod.Check,
+    paymentMethod: isDirectDeposit ? PaymentMethod.DirectDeposit : PaymentMethod.Check,
   };
 };

--- a/lambda-anchor-autofile-api/src/index.ts
+++ b/lambda-anchor-autofile-api/src/index.ts
@@ -25,10 +25,13 @@ const validateEvent = (event: unknown): AutofileLookupRequest | null => {
 
   const { ssn, zip } = event as Record<string, unknown>;
 
-  if (typeof ssn !== "string" || !/^\d{9}$/.test(ssn)) return null;
-  if (typeof zip !== "string" || !/^\d{5}$/.test(zip)) return null;
+  if (typeof ssn !== "string" || typeof zip !== "string") return null;
 
-  return { ssn, zip };
+  const sanitizedSsn = ssn.replace(/-/g, "");
+  if (!/^\d{9}$/.test(sanitizedSsn)) return null;
+  if (!/^\d{5}$/.test(zip)) return null;
+
+  return { ssn: sanitizedSsn, zip };
 };
 
 /** Response shape returned when validation fails. */

--- a/lambda-anchor-autofile-api/src/index.ts
+++ b/lambda-anchor-autofile-api/src/index.ts
@@ -19,11 +19,9 @@ export interface AutofileLookupResponse {
 
 const dynamoClient = new DynamoDBClient({});
 
-/** Validates that the event contains a valid SSN and ZIP. */
-const validateEvent = (event: unknown): AutofileLookupRequest | null => {
-  if (!event || typeof event !== "object") return null;
-
-  const { ssn, zip } = event as Record<string, unknown>;
+const validateEvent = (event: Record<string, unknown>): AutofileLookupRequest | null => {
+  const body = typeof event.body === "string" ? JSON.parse(event.body) : event;
+  const { ssn, zip } = body;
 
   if (typeof ssn !== "string" || typeof zip !== "string") return null;
 

--- a/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
@@ -6,20 +6,9 @@ export const AnchorAutofileCheckFaqContent: FaqItem[] = [
     content: (
       <>
         <p>
-          That's okay, nothing's wrong. The State is autofiling on your behalf regardless of whether
-          you received a letter. If you need to change your payment method or mailing address,
-          you'll need to file an application manually{" "}
-          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
-          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
-            a paper application
-          </a>{" "}
-          to:{" "}
+          In your case, the Division is filing on your behalf. You do not need to file an ANCHOR
+          application.
         </p>
-        <p>NJ Division of Taxation</p>
-        <p>Revenue Processing Center Property</p>
-        <p>Tax Relief Application</p>
-        <p>PO Box 636</p>
-        <p>Trenton, NJ 08646-0636</p>
       </>
     ),
     expanded: false,
@@ -28,57 +17,101 @@ export const AnchorAutofileCheckFaqContent: FaqItem[] = [
       fireEventWhenFaqOpened("faq_anchor_check_did_not_receive_confirmation_in_mail"),
   },
   {
-    title: "What if I need to change my banking information?",
+    title: "What if I need to change my mailing address?",
     content: (
       <>
         <p>
-          You'll need to file an application manually to change your banking information. Otherwise,
-          your benefit will go to the bank account on file from last year.
+          To update your mailing address you must file a{" "}
+          <a
+            href="https://propertytaxreliefapp.nj.gov/File/Eligibility"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            web application
+          </a>
+          .
         </p>
-        <p>
-          To file an application manually, you can do it
-          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
-          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
-            a paper application
-          </a>{" "}
-          to:{" "}
-        </p>
-        <p>NJ Division of Taxation</p>
-        <p>Revenue Processing Center Property</p>
-        <p>Tax Relief Application</p>
-        <p>PO Box 636</p>
-        <p>Trenton, NJ 08646-0636</p>
       </>
     ),
     expanded: false,
-    id: "faq_anchor_check_need_to_change_banking",
-    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_need_to_change_banking"),
+    id: "faq_anchor_check_need_to_change_mailing_address",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_need_to_change_mailing_address"),
   },
   {
-    title: "What if I need to change my banking information?",
+    title: "What if I want to switch from a physical check to a direct deposit payment?",
     content: (
       <>
         <p>
-          You'll need to file an application manually to change your banking information. Otherwise,
-          your benefit will go to the bank account on file from last year.
+          To update your payment method you must file a{" "}
+          <a
+            href="https://propertytaxreliefapp.nj.gov/File/Eligibility"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            web application
+          </a>
+          .
         </p>
-        <p>
-          To file an application manually, you can do it
-          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
-          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
-            a paper application
-          </a>{" "}
-          to:{" "}
-        </p>
-        <p>NJ Division of Taxation</p>
-        <p>Revenue Processing Center Property</p>
-        <p>Tax Relief Application</p>
-        <p>PO Box 636</p>
-        <p>Trenton, NJ 08646-0636</p>
       </>
     ),
     expanded: false,
-    id: "faq_anchor_check_need_to_change_banking",
-    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_need_to_change_banking"),
+    id: "faq_anchor_check_switch_physical_check_to_deposit",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_switch_physical_check_to_deposit"),
+  },
+  {
+    title: "I know I'm no longer eligible for ANCHOR anymore. How do I opt out?",
+    content: (
+      <>
+        <p>
+          If your eligibility has changed since last year, you must{" "}
+          <a
+            href="https://propertytaxreliefapp.nj.gov/ANCHOROptOut"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            opt out
+          </a>{" "}
+          before September 16, 2026. This lets the Division know not to file on your behalf and
+          avoids you having to repay those funds if you're not eligible this year.
+        </p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_check_no_longer_eligible_opt_out",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_no_longer_eligible_opt_out"),
+  },
+  {
+    title: "What happens if I submitted an application on my own?",
+    content: (
+      <>
+        <p>
+          The application you filed replaces the version we filed on your behalf. However, it must
+          be filed before September 16, 2026, when the Division files applications.
+        </p>
+        <p>If you miss the deadline, contact the Division:</p>
+        <ul>
+          <li>
+            Call: <a href="tel:+18882381233">1-888-238-1233</a> (Monday to Friday 8:30 a.m. to 5:30
+            p.m.)
+          </li>
+          <li>
+            Or email: <a href="mailto:nj.anchor@treas.nj.gov">nj.anchor@treas.nj.gov</a>
+          </li>
+          <li>
+            Or visit one of our{" "}
+            <a
+              href="https://www.nj.gov/treasury/taxation/contact-office.shtml"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Regional Information Centers
+            </a>
+          </li>
+        </ul>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_check_submitted_own_application",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_submitted_own_application"),
   },
 ];

--- a/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
@@ -1,0 +1,84 @@
+import { fireEventWhenFaqOpened, type FaqItem } from "@/components/FaqSection";
+
+export const AnchorAutofileCheckFaqContent: FaqItem[] = [
+  {
+    title: "What if I did not receive a ANCHOR Benefit Confirmation Letter in the mail?",
+    content: (
+      <>
+        <p>
+          That's okay, nothing's wrong. The State is autofiling on your behalf regardless of whether
+          you received a letter. If you need to change your payment method or mailing address,
+          you'll need to file an application manually{" "}
+          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
+          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
+            a paper application
+          </a>{" "}
+          to:{" "}
+        </p>
+        <p>NJ Division of Taxation</p>
+        <p>Revenue Processing Center Property</p>
+        <p>Tax Relief Application</p>
+        <p>PO Box 636</p>
+        <p>Trenton, NJ 08646-0636</p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_check_did_not_receive_confirmation_in_mail",
+    handleToggle: () =>
+      fireEventWhenFaqOpened("faq_anchor_check_did_not_receive_confirmation_in_mail"),
+  },
+  {
+    title: "What if I need to change my banking information?",
+    content: (
+      <>
+        <p>
+          You'll need to file an application manually to change your banking information. Otherwise,
+          your benefit will go to the bank account on file from last year.
+        </p>
+        <p>
+          To file an application manually, you can do it
+          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
+          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
+            a paper application
+          </a>{" "}
+          to:{" "}
+        </p>
+        <p>NJ Division of Taxation</p>
+        <p>Revenue Processing Center Property</p>
+        <p>Tax Relief Application</p>
+        <p>PO Box 636</p>
+        <p>Trenton, NJ 08646-0636</p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_check_need_to_change_banking",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_need_to_change_banking"),
+  },
+  {
+    title: "What if I need to change my banking information?",
+    content: (
+      <>
+        <p>
+          You'll need to file an application manually to change your banking information. Otherwise,
+          your benefit will go to the bank account on file from last year.
+        </p>
+        <p>
+          To file an application manually, you can do it
+          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
+          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
+            a paper application
+          </a>{" "}
+          to:{" "}
+        </p>
+        <p>NJ Division of Taxation</p>
+        <p>Revenue Processing Center Property</p>
+        <p>Tax Relief Application</p>
+        <p>PO Box 636</p>
+        <p>Trenton, NJ 08646-0636</p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_check_need_to_change_banking",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_check_need_to_change_banking"),
+  },
+];

--- a/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
@@ -2,7 +2,7 @@ import { fireEventWhenFaqOpened, type FaqItem } from "@/components/FaqSection";
 
 export const AnchorAutofileCheckFaqContent: FaqItem[] = [
   {
-    title: "What if I did not receive a ANCHOR Benefit Confirmation Letter in the mail?",
+    title: "What if I did not receive an ANCHOR Benefit Confirmation Letter in the mail?",
     content: (
       <>
         <p>

--- a/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileCheckFaqContent.tsx
@@ -85,29 +85,9 @@ export const AnchorAutofileCheckFaqContent: FaqItem[] = [
     content: (
       <>
         <p>
-          The application you filed replaces the version we filed on your behalf. However, it must
-          be filed before September 16, 2026, when the Division files applications.
+          If you file an application on your own before September 16, 2026, we will not file an
+          application on your behalf.
         </p>
-        <p>If you miss the deadline, contact the Division:</p>
-        <ul>
-          <li>
-            Call: <a href="tel:+18882381233">1-888-238-1233</a> (Monday to Friday 8:30 a.m. to 5:30
-            p.m.)
-          </li>
-          <li>
-            Or email: <a href="mailto:nj.anchor@treas.nj.gov">nj.anchor@treas.nj.gov</a>
-          </li>
-          <li>
-            Or visit one of our{" "}
-            <a
-              href="https://www.nj.gov/treasury/taxation/contact-office.shtml"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Regional Information Centers
-            </a>
-          </li>
-        </ul>
       </>
     ),
     expanded: false,

--- a/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
@@ -2,7 +2,7 @@ import { fireEventWhenFaqOpened, type FaqItem } from "@/components/FaqSection";
 
 export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
   {
-    title: "What if I did not receive a ANCHOR Benefit Confirmation Letter in the mail?",
+    title: "What if I did not receive an ANCHOR Benefit Confirmation Letter in the mail?",
     content: (
       <>
         <p>

--- a/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
@@ -85,29 +85,9 @@ export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
     content: (
       <>
         <p>
-          The application you filed replaces the version we filed on your behalf. However, it must
-          be filed before September 16, 2026, when the Division files applications.
+          If you file an application on your own before September 16, 2026, we will not file an
+          application on your behalf.
         </p>
-        <p>If you miss the deadline, contact the Division:</p>
-        <ul>
-          <li>
-            Call: <a href="tel:+18882381233">1-888-238-1233</a> (Monday to Friday 8:30 a.m. to 5:30
-            p.m.)
-          </li>
-          <li>
-            Or email: <a href="mailto:nj.anchor@treas.nj.gov">nj.anchor@treas.nj.gov</a>
-          </li>
-          <li>
-            Or visit one of our{" "}
-            <a
-              href="https://www.nj.gov/treasury/taxation/contact-office.shtml"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Regional Information Centers
-            </a>
-          </li>
-        </ul>
       </>
     ),
     expanded: false,

--- a/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
@@ -6,20 +6,9 @@ export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
     content: (
       <>
         <p>
-          That's okay, nothing's wrong. The State is autofiling on your behalf regardless of whether
-          you received a letter. If you need to change your payment method or mailing address,
-          you'll need to file an application manually{" "}
-          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
-          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
-            a paper application
-          </a>{" "}
-          to:{" "}
+          In your case, the Division is filing on your behalf. You do not need to file an ANCHOR
+          application.
         </p>
-        <p>NJ Division of Taxation</p>
-        <p>Revenue Processing Center Property</p>
-        <p>Tax Relief Application</p>
-        <p>PO Box 636</p>
-        <p>Trenton, NJ 08646-0636</p>
       </>
     ),
     expanded: false,
@@ -28,53 +17,41 @@ export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
       fireEventWhenFaqOpened("faq_anchor_dd_did_not_receive_confirmation_in_mail"),
   },
   {
-    title: "What if I need to change my banking information?",
+    title: "What if I need to update my banking information?",
     content: (
       <>
         <p>
-          You'll need to file an application manually to change your banking information. Otherwise,
-          your benefit will go to the bank account on file from last year.
+          To update your banking information you must file a{" "}
+          <a
+            href="https://propertytaxreliefapp.nj.gov/File/Eligibility"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            web application
+          </a>
+          .
         </p>
-        <p>
-          To file an application manually, you can do it
-          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
-          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
-            a paper application
-          </a>{" "}
-          to:{" "}
-        </p>
-        <p>NJ Division of Taxation</p>
-        <p>Revenue Processing Center Property</p>
-        <p>Tax Relief Application</p>
-        <p>PO Box 636</p>
-        <p>Trenton, NJ 08646-0636</p>
       </>
     ),
     expanded: false,
-    id: "faq_anchor_dd_need_to_change_banking",
-    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_need_to_change_banking"),
+    id: "faq_anchor_dd_need_to_update_banking",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_need_to_update_banking"),
   },
   {
     title: "How can I switch from a direct deposit payment to a physical check?",
     content: (
       <>
         <p>
-          You'll need to file an application manually to change your payment method. Otherwise, your
-          benefit will be directly deposited.
+          To update your payment method you must file a{" "}
+          <a
+            href="https://propertytaxreliefapp.nj.gov/File/Eligibility"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            web application
+          </a>
+          .
         </p>
-        <p>
-          To file an application manually, you can do it
-          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
-          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
-            a paper application
-          </a>{" "}
-          to:{" "}
-        </p>
-        <p>NJ Division of Taxation</p>
-        <p>Revenue Processing Center Property</p>
-        <p>Tax Relief Application</p>
-        <p>PO Box 636</p>
-        <p>Trenton, NJ 08646-0636</p>
       </>
     ),
     expanded: false,
@@ -82,14 +59,20 @@ export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
     handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_need_to_switch_to_check"),
   },
   {
-    title: "I know I'm no longer eligible for ANCHOR anymore. What do I need to do?",
+    title: "I know I'm no longer eligible for ANCHOR anymore. How do I opt out?",
     content: (
       <>
         <p>
-          If your eligibility has changed since last year, you can{" "}
-          <a href="https://propertytaxreliefapp.nj.gov/ANCHOROptOut">opt out of autofiling</a>. This
-          lets the State know not to file on your behalf, so you won't be autofiled for a benefit
-          you may no longer qualify for.
+          If your eligibility has changed since last year, you must{" "}
+          <a
+            href="https://propertytaxreliefapp.nj.gov/ANCHOROptOut"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            opt out
+          </a>{" "}
+          before September 16, 2026. This lets the Division know not to file on your behalf and
+          avoids you having to repay those funds if you're not eligible this year.
         </p>
       </>
     ),
@@ -98,38 +81,29 @@ export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
     handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_no_longer_eligible_for_anchor"),
   },
   {
-    title: "What happens if I submit a manual application?",
+    title: "What happens if I submitted an application on my own?",
     content: (
       <>
         <p>
-          A manual application overrides the autofiled version. However, it must be submitted before
-          September 15, when the State files autofiled applications. Submitting after that date will
-          be too late to make changes. To manually submit an application, you can do it{" "}
-          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
-          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
-            a paper application
-          </a>{" "}
-          to:
+          The application you filed replaces the version we filed on your behalf. However, it must
+          be filed before September 16, 2026, when the Division files applications.
         </p>
-
-        <p>NJ Division of Taxation</p>
-        <p>Revenue Processing Center Property</p>
-        <p>Tax Relief Application</p>
-        <p>PO Box 636</p>
-        <p>Trenton, NJ 08646-0636</p>
-
-        <p>
-          If your check is sent to the wrong address, or your direct deposit goes to the wrong
-          account, contact the Division to have it corrected using one of the following:
-        </p>
+        <p>If you miss the deadline, contact the Division:</p>
         <ul>
-          <li>Call: 1-888-238-1233 (Monday to Friday 8:30 a.m. to 5:30 p.m.)</li>
           <li>
-            Email: <a href="mailto:nj.anchor@treas.nj.gov">nj.anchor@treas.nj.gov</a>
+            Call: <a href="tel:+18882381233">1-888-238-1233</a> (Monday to Friday 8:30 a.m. to 5:30
+            p.m.)
           </li>
           <li>
-            Visit one of our{" "}
-            <a href="https://www.nj.gov/treasury/taxation/contact-office.shtml">
+            Or email: <a href="mailto:nj.anchor@treas.nj.gov">nj.anchor@treas.nj.gov</a>
+          </li>
+          <li>
+            Or visit one of our{" "}
+            <a
+              href="https://www.nj.gov/treasury/taxation/contact-office.shtml"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Regional Information Centers
             </a>
           </li>
@@ -137,7 +111,7 @@ export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
       </>
     ),
     expanded: false,
-    id: "faq_anchor_dd_no_longer_eligible_for_anchor",
-    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_no_longer_eligible_for_anchor"),
+    id: "faq_anchor_dd_submitted_own_application",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_submitted_own_application"),
   },
 ];

--- a/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
+++ b/webapp/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent.tsx
@@ -1,0 +1,143 @@
+import { fireEventWhenFaqOpened, type FaqItem } from "@/components/FaqSection";
+
+export const AnchorAutofileDirectDepositFaqContent: FaqItem[] = [
+  {
+    title: "What if I did not receive a ANCHOR Benefit Confirmation Letter in the mail?",
+    content: (
+      <>
+        <p>
+          That's okay, nothing's wrong. The State is autofiling on your behalf regardless of whether
+          you received a letter. If you need to change your payment method or mailing address,
+          you'll need to file an application manually{" "}
+          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
+          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
+            a paper application
+          </a>{" "}
+          to:{" "}
+        </p>
+        <p>NJ Division of Taxation</p>
+        <p>Revenue Processing Center Property</p>
+        <p>Tax Relief Application</p>
+        <p>PO Box 636</p>
+        <p>Trenton, NJ 08646-0636</p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_dd_did_not_receive_confirmation_in_mail",
+    handleToggle: () =>
+      fireEventWhenFaqOpened("faq_anchor_dd_did_not_receive_confirmation_in_mail"),
+  },
+  {
+    title: "What if I need to change my banking information?",
+    content: (
+      <>
+        <p>
+          You'll need to file an application manually to change your banking information. Otherwise,
+          your benefit will go to the bank account on file from last year.
+        </p>
+        <p>
+          To file an application manually, you can do it
+          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
+          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
+            a paper application
+          </a>{" "}
+          to:{" "}
+        </p>
+        <p>NJ Division of Taxation</p>
+        <p>Revenue Processing Center Property</p>
+        <p>Tax Relief Application</p>
+        <p>PO Box 636</p>
+        <p>Trenton, NJ 08646-0636</p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_dd_need_to_change_banking",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_need_to_change_banking"),
+  },
+  {
+    title: "How can I switch from a direct deposit payment to a physical check?",
+    content: (
+      <>
+        <p>
+          You'll need to file an application manually to change your payment method. Otherwise, your
+          benefit will be directly deposited.
+        </p>
+        <p>
+          To file an application manually, you can do it
+          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
+          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
+            a paper application
+          </a>{" "}
+          to:{" "}
+        </p>
+        <p>NJ Division of Taxation</p>
+        <p>Revenue Processing Center Property</p>
+        <p>Tax Relief Application</p>
+        <p>PO Box 636</p>
+        <p>Trenton, NJ 08646-0636</p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_dd_need_to_switch_to_check",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_need_to_switch_to_check"),
+  },
+  {
+    title: "I know I'm no longer eligible for ANCHOR anymore. What do I need to do?",
+    content: (
+      <>
+        <p>
+          If your eligibility has changed since last year, you can{" "}
+          <a href="https://propertytaxreliefapp.nj.gov/ANCHOROptOut">opt out of autofiling</a>. This
+          lets the State know not to file on your behalf, so you won't be autofiled for a benefit
+          you may no longer qualify for.
+        </p>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_dd_no_longer_eligible_for_anchor",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_no_longer_eligible_for_anchor"),
+  },
+  {
+    title: "What happens if I submit a manual application?",
+    content: (
+      <>
+        <p>
+          A manual application overrides the autofiled version. However, it must be submitted before
+          September 15, when the State files autofiled applications. Submitting after that date will
+          be too late to make changes. To manually submit an application, you can do it{" "}
+          <a href="https://propertytaxreliefapp.nj.gov/">online</a> or by mailing{" "}
+          <a href="https://www.nj.gov/treasury/taxation/propertyreliefforms.shtml">
+            a paper application
+          </a>{" "}
+          to:
+        </p>
+
+        <p>NJ Division of Taxation</p>
+        <p>Revenue Processing Center Property</p>
+        <p>Tax Relief Application</p>
+        <p>PO Box 636</p>
+        <p>Trenton, NJ 08646-0636</p>
+
+        <p>
+          If your check is sent to the wrong address, or your direct deposit goes to the wrong
+          account, contact the Division to have it corrected using one of the following:
+        </p>
+        <ul>
+          <li>Call: 1-888-238-1233 (Monday to Friday 8:30 a.m. to 5:30 p.m.)</li>
+          <li>
+            Email: <a href="mailto:nj.anchor@treas.nj.gov">nj.anchor@treas.nj.gov</a>
+          </li>
+          <li>
+            Visit one of our{" "}
+            <a href="https://www.nj.gov/treasury/taxation/contact-office.shtml">
+              Regional Information Centers
+            </a>
+          </li>
+        </ul>
+      </>
+    ),
+    expanded: false,
+    id: "faq_anchor_dd_no_longer_eligible_for_anchor",
+    handleToggle: () => fireEventWhenFaqOpened("faq_anchor_dd_no_longer_eligible_for_anchor"),
+  },
+];

--- a/webapp/app/anchor-autofile/page.tsx
+++ b/webapp/app/anchor-autofile/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { ProcessList, ProcessListHeading, ProcessListItem } from "@trussworks/react-uswds";
 import { FaqSection } from "@/components/FaqSection";
 import { PaymentMethod } from "@/components/types";
+import { TaxpayerInfoHeader } from "@/components/TaxpayerInfoHeader";
 import { AnchorAutofileCheckFaqContent } from "./AnchorAutofileCheckFaqContent";
 import { AnchorAutofileDirectDepositFaqContent } from "./AnchorAutofileDirectDepositFaqContent";
 
@@ -41,32 +42,11 @@ const AnchorAutofilePage = () => {
               Log out
             </Link>
           </div>
-          <div>
-            <div className="grid-row">
-              <div className="tablet:grid-col-4">
-                <p>
-                  SSN/ITIN: <strong>***-**-{lastFourSsnDigits}</strong>
-                </p>
-              </div>
-              <div className="tablet:grid-col-4">
-                <p>
-                  ZIP Code: <strong>{zipCode}</strong>
-                </p>
-              </div>{" "}
-              <div className="tablet:grid-col-4">
-                <p>
-                  Tax Year: <strong>2025</strong>
-                </p>
-              </div>
-            </div>
-            <div className="grid-row">
-              <div className="tablet:grid-col-6">
-                <p>
-                  Payment Type: <strong>{paymentMethodString}</strong>
-                </p>
-              </div>
-            </div>
-          </div>
+          <TaxpayerInfoHeader
+            lastFourSsnDigits={lastFourSsnDigits}
+            zipCode={zipCode}
+            paymentType={paymentMethodString}
+          />
           <div className="margin-top-4">
             <h1 className="font-heading-xl">
               A 2025 ANCHOR application will be filed on your behalf on September 15, 2026.

--- a/webapp/app/anchor-autofile/page.tsx
+++ b/webapp/app/anchor-autofile/page.tsx
@@ -16,14 +16,14 @@ const AnchorAutofilePage = () => {
   const { dataStore } = useDataStore();
 
   useEffect(() => {
-    if (!dataStore || dataStore.kind !== DataType.AUTOFILE) {
+    if (!dataStore || dataStore.type !== DataType.AUTOFILE) {
       router.replace("/");
     }
   }, [dataStore, router]);
 
   // Next.js prerenders client components during the build,
   // returning null here allows it to render only client-side
-  if (!dataStore || dataStore.kind !== DataType.AUTOFILE) {
+  if (!dataStore || dataStore.type !== DataType.AUTOFILE) {
     return null;
   }
 

--- a/webapp/app/anchor-autofile/page.tsx
+++ b/webapp/app/anchor-autofile/page.tsx
@@ -49,7 +49,7 @@ const AnchorAutofilePage = () => {
           />
           <div className="margin-top-4">
             <h1 className="font-heading-xl">
-              A 2025 ANCHOR application will be filed on your behalf on September 15, 2026.
+              A 2025 ANCHOR application will be filed on your behalf.
             </h1>
             <p>
               Our records show that you are eligible for the ANCHOR benefit. Below are next steps
@@ -58,21 +58,28 @@ const AnchorAutofilePage = () => {
             <ProcessList>
               <ProcessListItem>
                 <ProcessListHeading type="p">
-                  ANCHOR Benefit Confirmation Letters were sent on August 10, 2026
+                  Your ANCHOR Benefit Confirmation Letter was sent on August 10, 2026
                 </ProcessListHeading>
               </ProcessListItem>
               <ProcessListItem>
                 <ProcessListHeading type="p">
-                  ANCHOR application will be filed on September 15, 2026
+                  The Division will start processing applications September 16, 2026
                 </ProcessListHeading>
                 <p>
-                  This is automatically filed for you unless you submit a paper or web application
-                  yourself before this date.
+                  This will happen automatically unless you{" "}
+                  <a
+                    href="https://propertytaxreliefapp.nj.gov/ANCHOROptOut"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    opt out
+                  </a>{" "}
+                  before this date
                 </p>
               </ProcessListItem>
               <ProcessListItem>
                 <ProcessListHeading type="p">
-                  Payments will be made starting October 1, 2026
+                  ANCHOR payments will go out starting October 1, 2026
                 </ProcessListHeading>
                 <p>In some cases, payments will be made after 2026</p>
               </ProcessListItem>

--- a/webapp/app/anchor-autofile/page.tsx
+++ b/webapp/app/anchor-autofile/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
+import Link from "next/link";
+import { ProcessList, ProcessListHeading, ProcessListItem } from "@trussworks/react-uswds";
+import { FaqSection } from "@/components/FaqSection";
+import { PaymentMethod } from "@/components/types";
+import { AnchorAutofileCheckFaqContent } from "./AnchorAutofileCheckFaqContent";
+import { AnchorAutofileDirectDepositFaqContent } from "./AnchorAutofileDirectDepositFaqContent";
+
+const AnchorAutofilePage = () => {
+  const router = useRouter();
+  const { dataStore } = useDataStore();
+
+  useEffect(() => {
+    if (!dataStore || dataStore.kind !== DataType.AUTOFILE) {
+      router.replace("/");
+    }
+  }, [dataStore, router]);
+
+  // Next.js prerenders client components during the build,
+  // returning null here allows it to render only client-side
+  if (!dataStore || dataStore.kind !== DataType.AUTOFILE) {
+    return null;
+  }
+
+  const { lastFourSsnDigits, zipCode, paymentMethod } = dataStore;
+  const paymentMethodString = paymentMethod === PaymentMethod.CHECK ? "Check" : "Direct Deposit";
+
+  return (
+    <main id="main-content">
+      <section className="usa-section">
+        <div className="grid-container">
+          <div style={{ textAlign: "right" }}>
+            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
+              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
+                <use href="/img/sprite.svg#logout"></use>
+              </svg>
+              Log out
+            </Link>
+          </div>
+          <div>
+            <div className="grid-row">
+              <div className="tablet:grid-col-4">
+                <p>
+                  SSN/ITIN: <strong>***-**-{lastFourSsnDigits}</strong>
+                </p>
+              </div>
+              <div className="tablet:grid-col-4">
+                <p>
+                  ZIP Code: <strong>{zipCode}</strong>
+                </p>
+              </div>{" "}
+              <div className="tablet:grid-col-4">
+                <p>
+                  Tax Year: <strong>2025</strong>
+                </p>
+              </div>
+            </div>
+            <div className="grid-row">
+              <div className="tablet:grid-col-6">
+                <p>
+                  Payment Type: <strong>{paymentMethodString}</strong>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="margin-top-4">
+            <h1 className="font-heading-xl">
+              A 2025 ANCHOR application will be filed on your behalf on September 15, 2026.
+            </h1>
+            <p>
+              Our records show that you are eligible for the ANCHOR benefit. Below are next steps
+              you can expect:
+            </p>
+            <ProcessList>
+              <ProcessListItem>
+                <ProcessListHeading type="p">
+                  ANCHOR Benefit Confirmation Letters were sent on August 10, 2026
+                </ProcessListHeading>
+              </ProcessListItem>
+              <ProcessListItem>
+                <ProcessListHeading type="p">
+                  ANCHOR application will be filed on September 15, 2026
+                </ProcessListHeading>
+                <p>
+                  This is automatically filed for you unless you submit a paper or web application
+                  yourself before this date.
+                </p>
+              </ProcessListItem>
+              <ProcessListItem>
+                <ProcessListHeading type="p">
+                  Payments will be made starting October 1, 2026
+                </ProcessListHeading>
+                <p>In some cases, payments will be made after 2026</p>
+              </ProcessListItem>
+            </ProcessList>
+          </div>
+
+          {paymentMethod === PaymentMethod.CHECK && (
+            <FaqSection
+              items={AnchorAutofileCheckFaqContent}
+              titleHeadingLevel="h2"
+              itemHeadingLevel="h3"
+            />
+          )}
+
+          {paymentMethod === PaymentMethod.DIRECT_DEPOSIT && (
+            <FaqSection
+              items={AnchorAutofileDirectDepositFaqContent}
+              titleHeadingLevel="h2"
+              itemHeadingLevel="h3"
+            />
+          )}
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default AnchorAutofilePage;

--- a/webapp/app/anchor-autofile/page.tsx
+++ b/webapp/app/anchor-autofile/page.tsx
@@ -57,12 +57,12 @@ const AnchorAutofilePage = () => {
             </p>
             <ProcessList>
               <ProcessListItem>
-                <ProcessListHeading type="p">
+                <ProcessListHeading type="p" className="text-normal">
                   Your ANCHOR Benefit Confirmation Letter was sent on August 10, 2026
                 </ProcessListHeading>
               </ProcessListItem>
               <ProcessListItem>
-                <ProcessListHeading type="p">
+                <ProcessListHeading type="p" className="text-normal">
                   The Division will start processing applications September 16, 2026
                 </ProcessListHeading>
                 <p>
@@ -78,7 +78,7 @@ const AnchorAutofilePage = () => {
                 </p>
               </ProcessListItem>
               <ProcessListItem>
-                <ProcessListHeading type="p">
+                <ProcessListHeading type="p" className="text-normal">
                   ANCHOR payments will go out starting October 1, 2026
                 </ProcessListHeading>
                 <p>In some cases, payments will be made after 2026</p>

--- a/webapp/app/api/autofile/route.test.ts
+++ b/webapp/app/api/autofile/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+vi.mock("@aws-sdk/signature-v4", () => ({
+  SignatureV4: class {
+    sign = vi.fn().mockResolvedValue({
+      method: "POST",
+      headers: { "Content-Type": "application/json", host: "lambda.example.com" },
+      body: JSON.stringify({ ssn: "123456789", zip: "12345" }),
+    });
+  },
+}));
+
+vi.mock("@aws-crypto/sha256-js", () => ({ Sha256: class {} }));
+
+const createRequest = (body: unknown): NextRequest =>
+  new NextRequest("http://localhost/api/autofile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("POST /api/autofile", () => {
+  it("returns 400 when ssn is missing", async () => {
+    process.env.NEXT_PUBLIC_AUTOFILE_LAMBDA_API_URL = "https://lambda.example.com/invoke";
+
+    const response = await POST(createRequest({ ssn: "", zip: "12345" }));
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe("Both ssn and zip are required.");
+  });
+
+  it("returns 400 when zip is missing", async () => {
+    process.env.NEXT_PUBLIC_AUTOFILE_LAMBDA_API_URL = "https://lambda.example.com/invoke";
+
+    const response = await POST(createRequest({ ssn: "123456789", zip: "" }));
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBe("Both ssn and zip are required.");
+  });
+
+  it("proxies a successful lambda response", async () => {
+    process.env.NEXT_PUBLIC_AUTOFILE_LAMBDA_API_URL = "https://lambda.example.com/invoke";
+
+    const lambdaBody = { status: "filed", date: "2026-01-01" };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve(lambdaBody),
+    }) as unknown as typeof fetch;
+
+    const response = await POST(createRequest({ ssn: "123456789", zip: "12345" }));
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual(lambdaBody);
+  });
+
+  it("forwards the lambda status code for non-200 responses", async () => {
+    process.env.NEXT_PUBLIC_AUTOFILE_LAMBDA_API_URL = "https://lambda.example.com/invoke";
+
+    const lambdaBody = { error: "Not found" };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 404,
+      json: () => Promise.resolve(lambdaBody),
+    }) as unknown as typeof fetch;
+
+    const response = await POST(createRequest({ ssn: "123456789", zip: "12345" }));
+
+    expect(response.status).toBe(404);
+    const json = await response.json();
+    expect(json).toEqual(lambdaBody);
+  });
+});

--- a/webapp/app/api/autofile/route.ts
+++ b/webapp/app/api/autofile/route.ts
@@ -76,10 +76,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
     const lambdaBody: unknown = await lambdaResponse.json();
 
     return NextResponse.json(lambdaBody, { status: lambdaResponse.status });
-  } catch {
-    return NextResponse.json(
-      { error: "Failed to reach the autofile check service." },
-      { status: 502 },
-    );
+  } catch (err) {
+    return NextResponse.json({ error: err }, { status: 502 });
   }
 };

--- a/webapp/app/api/autofile/route.ts
+++ b/webapp/app/api/autofile/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { SignatureV4 } from "@aws-sdk/signature-v4";
+import { Sha256 } from "@aws-crypto/sha256-js";
+import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import { HttpRequest } from "@smithy/protocol-http";
+
+interface StatusRequestBody {
+  readonly ssn: string;
+  readonly zip: string;
+}
+
+/** Signs an outgoing HTTP request with AWS SigV4 so AWS_IAM auth can work. */
+const signRequest = async (config: {
+  readonly url: string;
+  readonly body: string;
+}): Promise<HttpRequest> => {
+  const parsedUrl = new URL(config.url);
+
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: parsedUrl.hostname,
+    path: parsedUrl.pathname,
+    headers: {
+      "Content-Type": "application/json",
+      host: parsedUrl.hostname,
+    },
+    body: config.body,
+  });
+
+  const signer = new SignatureV4({
+    service: "lambda",
+    region: "us-east-1",
+    credentials: defaultProvider(),
+    sha256: Sha256,
+  });
+
+  return (await signer.sign(request)) as HttpRequest;
+};
+
+/**
+ * POST /api/status
+ *
+ * Proxies the SSN + ZIP lookup to the AWS Lambda endpoint configured via
+ * NEXT_PUBLIC_AUTOFILE_LAMBDA_API_URL. Signs the request with SigV4 for AWS_IAM authentication on
+ * the Lambda Function URL.
+ */
+export const POST = async (request: NextRequest): Promise<NextResponse> => {
+  const lambdaUrl = process.env.NEXT_PUBLIC_AUTOFILE_LAMBDA_API_URL;
+
+  if (!lambdaUrl) {
+    return NextResponse.json({ error: "Autofile API is not configured." }, { status: 503 });
+  }
+
+  let body: StatusRequestBody;
+  try {
+    body = (await request.json()) as StatusRequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+
+  if (!body.ssn || !body.zip) {
+    return NextResponse.json({ error: "Both ssn and zip are required." }, { status: 400 });
+  }
+
+  try {
+    const payload = JSON.stringify({ ssn: body.ssn, zip: body.zip });
+    const signed = await signRequest({ url: lambdaUrl, body: payload });
+
+    const lambdaResponse = await fetch(lambdaUrl, {
+      method: signed.method,
+      headers: signed.headers,
+      body: signed.body,
+    });
+
+    const lambdaBody: unknown = await lambdaResponse.json();
+
+    return NextResponse.json(lambdaBody, { status: lambdaResponse.status });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to reach the autofile check service." },
+      { status: 502 },
+    );
+  }
+};

--- a/webapp/app/application-received/page.tsx
+++ b/webapp/app/application-received/page.tsx
@@ -14,14 +14,14 @@ const ApplicationReceivedPage = () => {
   const { dataStore } = useDataStore();
 
   useEffect(() => {
-    if (!dataStore || dataStore.kind !== DataType.STATUS) {
+    if (!dataStore || dataStore.type !== DataType.STATUS) {
       router.replace("/");
     }
   }, [dataStore, router]);
 
   // Next.js prerenders client components during the build,
   // returning null here allows it to render only client-side
-  if (!dataStore || dataStore.kind !== DataType.STATUS) {
+  if (!dataStore || dataStore.type !== DataType.STATUS) {
     return null;
   }
 

--- a/webapp/app/application-received/page.tsx
+++ b/webapp/app/application-received/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useDataStore } from "@/components/TaxReliefDataProvider";
+import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import Link from "next/link";
 import { ProcessList, ProcessListHeading, ProcessListItem } from "@trussworks/react-uswds";
 import { ApplicationReceivedFaqContent } from "./ApplicationReceivedFaqContent";
@@ -13,14 +13,14 @@ const ApplicationReceivedPage = () => {
   const { dataStore } = useDataStore();
 
   useEffect(() => {
-    if (!dataStore) {
+    if (!dataStore || dataStore.kind !== DataType.STATUS) {
       router.replace("/");
     }
   }, [dataStore, router]);
 
   // Next.js prerenders client components during the build,
   // returning null here allows it to render only client-side
-  if (!dataStore) {
+  if (!dataStore || dataStore.kind !== DataType.STATUS) {
     return null;
   }
 

--- a/webapp/app/application-received/page.tsx
+++ b/webapp/app/application-received/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { ProcessList, ProcessListHeading, ProcessListItem } from "@trussworks/react-uswds";
 import { ApplicationReceivedFaqContent } from "./ApplicationReceivedFaqContent";
 import { FaqSection } from "@/components/FaqSection";
+import { TaxpayerInfoHeader } from "@/components/TaxpayerInfoHeader";
 
 const ApplicationReceivedPage = () => {
   const router = useRouter();
@@ -38,25 +39,7 @@ const ApplicationReceivedPage = () => {
               Log out
             </Link>
           </div>
-          <div>
-            <div className="grid-row">
-              <div className="tablet:grid-col-3">
-                <p>
-                  SSN/ITIN: <strong>***-**-{lastFourSsnDigits}</strong>
-                </p>
-              </div>
-              <div className="tablet:grid-col-3">
-                <p>
-                  ZIP Code: <strong>{zipCode}</strong>
-                </p>
-              </div>{" "}
-              <div className="tablet:grid-col-3">
-                <p>
-                  Tax Year: <strong>2025</strong>
-                </p>
-              </div>
-            </div>
-          </div>
+          <TaxpayerInfoHeader lastFourSsnDigits={lastFourSsnDigits} zipCode={zipCode} />
           <div className="margin-top-4">
             <h1 className="font-heading-xl">
               Your application was received on {applicationDateString}

--- a/webapp/app/more-information-needed/page.tsx
+++ b/webapp/app/more-information-needed/page.tsx
@@ -6,6 +6,7 @@ import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import { IssueFlaggedType } from "@/components/types";
 import Link from "next/link";
 import { Alert } from "@trussworks/react-uswds";
+import { TaxpayerInfoHeader } from "@/components/TaxpayerInfoHeader";
 
 const MoreInformationNeededPage = () => {
   const router = useRouter();
@@ -90,25 +91,7 @@ const MoreInformationNeededPage = () => {
               Log out
             </Link>
           </div>
-          <div>
-            <div className="grid-row">
-              <div className="tablet:grid-col-3">
-                <p>
-                  SSN/ITIN: <strong>***-**-{lastFourSsnDigits}</strong>
-                </p>
-              </div>
-              <div className="tablet:grid-col-3">
-                <p>
-                  ZIP Code: <strong>{zipCode}</strong>
-                </p>
-              </div>{" "}
-              <div className="tablet:grid-col-3">
-                <p>
-                  Tax Year: <strong>2025</strong>
-                </p>
-              </div>
-            </div>
-          </div>
+          <TaxpayerInfoHeader lastFourSsnDigits={lastFourSsnDigits} zipCode={zipCode} />
           {issueFlagged !== undefined && (
             <Alert type="warning" headingLevel="h2" heading="Additional information needed">
               {createAlertContent(issueFlagged)}

--- a/webapp/app/more-information-needed/page.tsx
+++ b/webapp/app/more-information-needed/page.tsx
@@ -13,14 +13,14 @@ const MoreInformationNeededPage = () => {
   const { dataStore } = useDataStore();
 
   useEffect(() => {
-    if (!dataStore || dataStore.kind !== DataType.STATUS) {
+    if (!dataStore || dataStore.type !== DataType.STATUS) {
       router.replace("/");
     }
   }, [dataStore, router]);
 
   // Next.js prerenders client components during the build,
   // returning null here allows it to render only client-side
-  if (!dataStore || dataStore.kind !== DataType.STATUS) {
+  if (!dataStore || dataStore.type !== DataType.STATUS) {
     return null;
   }
 

--- a/webapp/app/more-information-needed/page.tsx
+++ b/webapp/app/more-information-needed/page.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useDataStore } from "@/components/TaxReliefDataProvider";
+import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import { IssueFlaggedType } from "@/components/types";
 import Link from "next/link";
 import { Alert } from "@trussworks/react-uswds";
@@ -12,14 +12,14 @@ const MoreInformationNeededPage = () => {
   const { dataStore } = useDataStore();
 
   useEffect(() => {
-    if (!dataStore) {
+    if (!dataStore || dataStore.kind !== DataType.STATUS) {
       router.replace("/");
     }
   }, [dataStore, router]);
 
   // Next.js prerenders client components during the build,
   // returning null here allows it to render only client-side
-  if (!dataStore) {
+  if (!dataStore || dataStore.kind !== DataType.STATUS) {
     return null;
   }
 

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -15,13 +15,11 @@ import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import { setIssueFlagged } from "./utils/setIssueFlagged";
 import { PaymentMethod, Transaction, TransactionStatus } from "@/components/types";
 
-/** Form data collected from the user. */
 interface UserData {
   readonly ssn: string;
   readonly zipCode: string;
 }
 
-/** Response shape returned by the status API. */
 export interface StatusRecord {
   readonly return_year: string;
   readonly application_date: string;
@@ -119,7 +117,7 @@ const LandingPage = () => {
 
       if (autofileResult?.autofilePlanned) {
         setDataStore({
-          kind: DataType.AUTOFILE,
+          type: DataType.AUTOFILE,
           lastFourSsnDigits: maskSsn(data.ssn),
           zipCode: data.zipCode,
           paymentMethod: autofileResult.paymentMethod,
@@ -194,7 +192,7 @@ const LandingPage = () => {
       const lastFourSsnDigits = maskSsn(data.ssn);
       const formattedDate = formatDate(record2025.application_date);
       setDataStore({
-        kind: DataType.STATUS,
+        type: DataType.STATUS,
         lastFourSsnDigits: lastFourSsnDigits,
         zipCode: data.zipCode,
         applicationDateString: formattedDate,

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -13,7 +13,7 @@ import { formatDate } from "@/app/utils/formatDate";
 import { logGAEvent } from "./utils/analytics";
 import { useDataStore } from "@/components/TaxReliefDataProvider";
 import { setIssueFlagged } from "./utils/setIssueFlagged";
-import { Transaction, TransactionStatus } from "@/components/types";
+import { PaymentMethod, Transaction, TransactionStatus } from "@/components/types";
 
 /** Form data collected from the user. */
 interface UserData {
@@ -29,6 +29,34 @@ export interface StatusRecord {
   readonly ptr: Transaction[];
   readonly stay_nj: Transaction[];
 }
+
+/** Response shape returned by the autofile API. */
+interface AutofileResponse {
+  readonly autofilePlanned: boolean;
+  readonly paymentMethod?: PaymentMethod;
+}
+
+/** Calls the autofile API to determine if the user is an ANCHOR autofile recipient. */
+const checkAutofile = async (config: {
+  readonly ssn: string;
+  readonly zip: string;
+}): Promise<AutofileResponse | null> => {
+  try {
+    const response = await fetch("/api/autofile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ssn: config.ssn, zip: config.zip }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as AutofileResponse;
+  } catch {
+    return null;
+  }
+};
 
 const hasPaymentSentTransaction = (record: StatusRecord) => {
   return (
@@ -76,6 +104,23 @@ const LandingPage = () => {
     setAlertContent(null);
 
     try {
+      const autofileResult = await checkAutofile({ ssn: data.ssn, zip: data.zipCode });
+
+      if (autofileResult?.autofilePlanned) {
+        setDataStore({
+          lastFourSsnDigits: maskSsn(data.ssn),
+          zipCode: data.zipCode,
+          applicationDateString: "",
+          anchor: [],
+          ptr: [],
+          stay_nj: [],
+          paymentMethod: autofileResult.paymentMethod,
+        });
+        logGAEvent(`autofile_planned`);
+        router.push("/anchor-autofile");
+        return;
+      }
+
       const response = await fetch("/api/status", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -11,7 +11,7 @@ import { FaqSection, expandFaqAccordionItem } from "@/components/FaqSection";
 import { maskSsn } from "@/app/utils/maskSsn";
 import { formatDate } from "@/app/utils/formatDate";
 import { logGAEvent } from "./utils/analytics";
-import { useDataStore } from "@/components/TaxReliefDataProvider";
+import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import { setIssueFlagged } from "./utils/setIssueFlagged";
 import { PaymentMethod, Transaction, TransactionStatus } from "@/components/types";
 
@@ -58,13 +58,6 @@ const checkAutofile = async (config: {
   }
 };
 
-const hasPaymentSentTransaction = (record: StatusRecord) => {
-  return (
-    hasTransactionWithStatus(record.anchor, TransactionStatus.PAYMENT_SENT) ||
-    hasTransactionWithStatus(record.ptr, TransactionStatus.PAYMENT_SENT)
-  );
-};
-
 const hasTransactionWithStatus = (
   transactionList: Transaction[],
   status: TransactionStatus,
@@ -75,6 +68,25 @@ const hasTransactionWithStatus = (
     }
   }
   return false;
+};
+
+const hasPaymentSentTransaction = (record: StatusRecord) => {
+  return (
+    hasTransactionWithStatus(record.anchor, TransactionStatus.PAYMENT_SENT) ||
+    hasTransactionWithStatus(record.ptr, TransactionStatus.PAYMENT_SENT)
+  );
+};
+
+const determineRoute = (record: StatusRecord): string => {
+  if (hasPaymentSentTransaction(record)) {
+    return "/payment-info";
+  }
+
+  if (setIssueFlagged(record) !== undefined) {
+    return "/more-information-needed";
+  }
+
+  return "/application-received";
 };
 
 const returnToTop = () => {
@@ -108,15 +120,12 @@ const LandingPage = () => {
 
       if (autofileResult?.autofilePlanned) {
         setDataStore({
+          kind: DataType.AUTOFILE,
           lastFourSsnDigits: maskSsn(data.ssn),
           zipCode: data.zipCode,
-          applicationDateString: "",
-          anchor: [],
-          ptr: [],
-          stay_nj: [],
           paymentMethod: autofileResult.paymentMethod,
         });
-        logGAEvent(`autofile_planned`);
+        logGAEvent(`autofile_${autofileResult.paymentMethod}`);
         router.push("/anchor-autofile");
         return;
       }
@@ -186,6 +195,7 @@ const LandingPage = () => {
       const lastFourSsnDigits = maskSsn(data.ssn);
       const formattedDate = formatDate(record2025.application_date);
       setDataStore({
+        kind: DataType.STATUS,
         lastFourSsnDigits: lastFourSsnDigits,
         zipCode: data.zipCode,
         applicationDateString: formattedDate,
@@ -195,13 +205,7 @@ const LandingPage = () => {
         issueFlagged: setIssueFlagged(record2025),
       });
       logGAEvent(`api_200_record_found`);
-      if (hasPaymentSentTransaction(record2025)) {
-        router.push("/payment-info");
-      } else if (setIssueFlagged(record2025) !== undefined) {
-        router.push("/more-information-needed");
-      } else {
-        router.push("/application-received");
-      }
+      router.push(determineRoute(record2025));
     } catch {
       setAlertContent(
         <p className="usa-alert__text maxw-tablet">

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -30,14 +30,12 @@ export interface StatusRecord {
   readonly stay_nj: Transaction[];
 }
 
-/** Response shape returned by the autofile API. */
 interface AutofileResponse {
   readonly autofilePlanned: boolean;
   readonly paymentMethod?: PaymentMethod;
 }
 
-/** Calls the autofile API to determine if the user is an ANCHOR autofile recipient. */
-const checkAutofile = async (config: {
+const checkAutofile = async (params: {
   readonly ssn: string;
   readonly zip: string;
 }): Promise<AutofileResponse | null> => {
@@ -45,7 +43,7 @@ const checkAutofile = async (config: {
     const response = await fetch("/api/autofile", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ssn: config.ssn, zip: config.zip }),
+      body: JSON.stringify({ ssn: params.ssn, zip: params.zip }),
     });
 
     if (!response.ok) {
@@ -54,6 +52,7 @@ const checkAutofile = async (config: {
 
     return (await response.json()) as AutofileResponse;
   } catch {
+    console.log("checkAutoFile failure");
     return null;
   }
 };

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -45,37 +45,23 @@ const checkAutofile = async (params: {
     });
 
     if (!response.ok) {
+      logGAEvent(`autofile_api_error`);
       return null;
     }
 
     return (await response.json()) as AutofileResponse;
   } catch {
-    console.log("checkAutoFile failure");
+    logGAEvent(`autofile_api_error`);
     return null;
   }
 };
 
-const hasTransactionWithStatus = (
-  transactionList: Transaction[],
-  status: TransactionStatus,
-): boolean => {
-  for (const t of transactionList) {
-    if (t.status === status) {
-      return true;
-    }
-  }
-  return false;
-};
-
-const hasPaymentSentTransaction = (record: StatusRecord) => {
-  return (
-    hasTransactionWithStatus(record.anchor, TransactionStatus.PAYMENT_SENT) ||
-    hasTransactionWithStatus(record.ptr, TransactionStatus.PAYMENT_SENT)
-  );
-};
-
 const determineRoute = (record: StatusRecord): string => {
-  if (hasPaymentSentTransaction(record)) {
+  const hasPaymentSentTransaction = [...record.anchor, ...record.ptr].some(
+    (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
+  );
+
+  if (hasPaymentSentTransaction) {
     return "/payment-info";
   }
 

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -9,6 +9,7 @@ import { formatDate } from "../utils/formatDate";
 import { PaymentInfoFaqContent } from "@/app/payment-info/PaymentInfoFaqContent";
 import { FaqSection, expandFaqAccordionItem } from "@/components/FaqSection";
 import { Transaction, TaxProgram, PaymentMethod, TransactionStatus } from "@/components/types";
+import { TaxpayerInfoHeader } from "@/components/TaxpayerInfoHeader";
 
 export const getEarliestTransaction = (transactions: Transaction[]) => {
   const valid = transactions.filter(
@@ -109,25 +110,7 @@ const PaymentInfoPage = () => {
               Log out
             </Link>
           </div>
-          <div>
-            <div className="grid-row">
-              <div className="tablet:grid-col-3">
-                <p>
-                  SSN/ITIN: <strong>***-**-{lastFourSsnDigits}</strong>
-                </p>
-              </div>
-              <div className="tablet:grid-col-3">
-                <p>
-                  ZIP Code: <strong>{zipCode}</strong>
-                </p>
-              </div>{" "}
-              <div className="tablet:grid-col-3">
-                <p>
-                  Tax Year: <strong>2025</strong>
-                </p>
-              </div>
-            </div>
-          </div>
+          <TaxpayerInfoHeader lastFourSsnDigits={lastFourSsnDigits} zipCode={zipCode} />
           <div className="margin-top-4">
             <h1 className="font-heading-xl">You are eligible for benefits</h1>
           </div>

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -2,7 +2,7 @@
 
 import { JSX, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useDataStore } from "@/components/TaxReliefDataProvider";
+import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import Link from "next/link";
 import { Table } from "@trussworks/react-uswds";
 import { formatDate } from "../utils/formatDate";
@@ -84,14 +84,14 @@ const PaymentInfoPage = () => {
   const { dataStore } = useDataStore();
 
   useEffect(() => {
-    if (!dataStore) {
+    if (!dataStore || dataStore.kind !== DataType.STATUS) {
       router.replace("/");
     }
   }, [dataStore, router]);
 
   // Next.js prerenders client components during the build,
   // returning null here allows it to render only client-side
-  if (!dataStore) {
+  if (!dataStore || dataStore.kind !== DataType.STATUS) {
     return null;
   }
 

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -85,14 +85,14 @@ const PaymentInfoPage = () => {
   const { dataStore } = useDataStore();
 
   useEffect(() => {
-    if (!dataStore || dataStore.kind !== DataType.STATUS) {
+    if (!dataStore || dataStore.type !== DataType.STATUS) {
       router.replace("/");
     }
   }, [dataStore, router]);
 
   // Next.js prerenders client components during the build,
   // returning null here allows it to render only client-side
-  if (!dataStore || dataStore.kind !== DataType.STATUS) {
+  if (!dataStore || dataStore.type !== DataType.STATUS) {
     return null;
   }
 

--- a/webapp/components/TaxReliefDataProvider.tsx
+++ b/webapp/components/TaxReliefDataProvider.tsx
@@ -10,14 +10,14 @@ export enum DataType {
 }
 
 export interface AutofileData {
-  readonly kind: DataType.AUTOFILE;
+  readonly type: DataType.AUTOFILE;
   readonly lastFourSsnDigits: string;
   readonly zipCode: string;
   readonly paymentMethod?: PaymentMethod;
 }
 
 export interface StatusData {
-  readonly kind: DataType.STATUS;
+  readonly type: DataType.STATUS;
   readonly lastFourSsnDigits: string;
   readonly zipCode: string;
   readonly applicationDateString: string;

--- a/webapp/components/TaxReliefDataProvider.tsx
+++ b/webapp/components/TaxReliefDataProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState } from "react";
 import type { ReactNode } from "react";
-import { IssueFlaggedType, Transaction } from "./types";
+import { IssueFlaggedType, PaymentMethod, Transaction } from "./types";
 
 export interface TaxReliefStatusData {
   readonly lastFourSsnDigits: string;
@@ -12,6 +12,8 @@ export interface TaxReliefStatusData {
   readonly anchor: Transaction[];
   readonly ptr: Transaction[];
   readonly stay_nj: Transaction[];
+  /** Payment method for ANCHOR autofile recipients (CHECK or DIRECT_DEPOSIT). */
+  readonly paymentMethod?: PaymentMethod;
 }
 
 const TaxReliefDataContext = createContext<{

--- a/webapp/components/TaxReliefDataProvider.tsx
+++ b/webapp/components/TaxReliefDataProvider.tsx
@@ -4,7 +4,20 @@ import { createContext, useContext, useState } from "react";
 import type { ReactNode } from "react";
 import { IssueFlaggedType, PaymentMethod, Transaction } from "./types";
 
-export interface TaxReliefStatusData {
+export enum DataType {
+  AUTOFILE,
+  STATUS,
+}
+
+export interface AutofileData {
+  readonly kind: DataType.AUTOFILE;
+  readonly lastFourSsnDigits: string;
+  readonly zipCode: string;
+  readonly paymentMethod?: PaymentMethod;
+}
+
+export interface StatusData {
+  readonly kind: DataType.STATUS;
   readonly lastFourSsnDigits: string;
   readonly zipCode: string;
   readonly applicationDateString: string;
@@ -12,9 +25,9 @@ export interface TaxReliefStatusData {
   readonly anchor: Transaction[];
   readonly ptr: Transaction[];
   readonly stay_nj: Transaction[];
-  /** Payment method for ANCHOR autofile recipients (CHECK or DIRECT_DEPOSIT). */
-  readonly paymentMethod?: PaymentMethod;
 }
+
+export type TaxReliefStatusData = AutofileData | StatusData;
 
 const TaxReliefDataContext = createContext<{
   dataStore: TaxReliefStatusData | null;

--- a/webapp/components/TaxpayerInfoHeader.test.tsx
+++ b/webapp/components/TaxpayerInfoHeader.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { expect } from "vitest";
+import { TaxpayerInfoHeader } from "./TaxpayerInfoHeader";
+
+describe("header component", () => {
+  it("renders the header with no payment method", () => {
+    render(<TaxpayerInfoHeader lastFourSsnDigits="0123" zipCode="12345" />);
+    expect(document.body.textContent).toContain("SSN/ITIN: ***-**-0123");
+    expect(document.body.textContent).toContain("ZIP Code: 12345");
+    expect(document.body.textContent).toContain("Tax Year: 2025");
+    expect(document.body.textContent).not.toContain("Payment Type");
+  });
+
+  it("renders the header with a check payment method", () => {
+    render(<TaxpayerInfoHeader lastFourSsnDigits="0123" zipCode="12345" paymentType="Check" />);
+    expect(document.body.textContent).toContain("SSN/ITIN: ***-**-0123");
+    expect(document.body.textContent).toContain("ZIP Code: 12345");
+    expect(document.body.textContent).toContain("Tax Year: 2025");
+    expect(document.body.textContent).toContain("Payment Type: Check");
+  });
+
+  it("renders the header with a direct deposit payment method", () => {
+    render(
+      <TaxpayerInfoHeader lastFourSsnDigits="0123" zipCode="12345" paymentType="Direct Deposit" />,
+    );
+    expect(document.body.textContent).toContain("SSN/ITIN: ***-**-0123");
+    expect(document.body.textContent).toContain("ZIP Code: 12345");
+    expect(document.body.textContent).toContain("Tax Year: 2025");
+    expect(document.body.textContent).toContain("Payment Type: Direct Deposit");
+  });
+});

--- a/webapp/components/TaxpayerInfoHeader.tsx
+++ b/webapp/components/TaxpayerInfoHeader.tsx
@@ -1,0 +1,44 @@
+export interface TaxpayerInfoHeaderProps {
+  readonly lastFourSsnDigits: string;
+  readonly zipCode: string;
+  readonly paymentType?: string;
+}
+
+export const TaxpayerInfoHeader = ({
+  lastFourSsnDigits,
+  zipCode,
+  paymentType,
+}: TaxpayerInfoHeaderProps) => {
+  const colSize = "tablet:grid-col-4";
+
+  return (
+    <div>
+      <div className="grid-row">
+        <div className={colSize}>
+          <p>
+            SSN/ITIN: <strong>***-**-{lastFourSsnDigits}</strong>
+          </p>
+        </div>
+        <div className={colSize}>
+          <p>
+            ZIP Code: <strong>{zipCode}</strong>
+          </p>
+        </div>{" "}
+        <div className={colSize}>
+          <p>
+            Tax Year: <strong>2025</strong>
+          </p>
+        </div>
+      </div>
+      {paymentType && (
+        <div className="grid-row">
+          <div className="tablet:grid-col-6">
+            <p>
+              Payment Type: <strong>{paymentType}</strong>
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/webapp/components/TaxpayerInfoHeader.tsx
+++ b/webapp/components/TaxpayerInfoHeader.tsx
@@ -23,7 +23,7 @@ export const TaxpayerInfoHeader = ({
           <p>
             ZIP Code: <strong>{zipCode}</strong>
           </p>
-        </div>{" "}
+        </div>
         <div className={colSize}>
           <p>
             Tax Year: <strong>2025</strong>

--- a/webapp/cypress/e2e/applicationReceived.cy.ts
+++ b/webapp/cypress/e2e/applicationReceived.cy.ts
@@ -34,6 +34,10 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_not_planned.json",
+  });
   fillFields();
 });
 

--- a/webapp/cypress/e2e/autofile.cy.ts
+++ b/webapp/cypress/e2e/autofile.cy.ts
@@ -1,0 +1,87 @@
+import { AnchorAutofileCheckFaqContent } from "@/app/anchor-autofile/AnchorAutofileCheckFaqContent";
+import { AnchorAutofileDirectDepositFaqContent } from "@/app/anchor-autofile/AnchorAutofileDirectDepositFaqContent";
+
+import { fillFields, MOCK_SSN, MOCK_ZIP } from "./utils";
+
+beforeEach(() => {
+  cy.on("window:before:load", (win) => {
+    win.gtag = cy.stub().as("gtag");
+  });
+  cy.visit("/");
+  fillFields();
+});
+
+it("should route the user to the autofile page when autofile API returns true with CHECK", () => {
+  fillFields();
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_check.json",
+  });
+  cy.contains("button", `Check Status`).click();
+  cy.contains(
+    "h1",
+    "A 2025 ANCHOR application will be filed on your behalf on September 15, 2026.",
+  ).should("be.visible");
+  cy.get("@gtag").should(
+    "have.been.calledWith",
+    "event",
+    "autofile_check",
+    Cypress.sinon.match.any,
+  );
+  cy.contains("p", "SSN/ITIN: ***-**-").should("be.visible");
+  cy.contains("p", MOCK_SSN.slice(-4)).should("be.visible");
+  cy.contains("p", "ZIP Code:").should("be.visible");
+  cy.contains("p", MOCK_ZIP).should("be.visible");
+  cy.contains("p", "Tax Year: 2025").should("be.visible");
+  cy.contains("p", "Payment Type: Check").should("be.visible");
+
+  for (const faq of AnchorAutofileCheckFaqContent) {
+    cy.contains("button", faq.title as string).click();
+    cy.get(`div[id="${faq.id}"]`).should("be.visible");
+    cy.get("@gtag").should(
+      "have.been.calledWith",
+      "event",
+      `${faq.id}_opened`,
+      Cypress.sinon.match.any,
+    );
+    cy.contains("button", faq.title as string).click();
+    cy.get(`div[id="${faq.id}"]`).should("not.be.visible");
+  }
+});
+
+it("should route the user to the autofile page when autofile API returns true with Direct Deposit", () => {
+  fillFields();
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_direct_deposit.json",
+  });
+  cy.contains("button", `Check Status`).click();
+  cy.contains(
+    "h1",
+    "A 2025 ANCHOR application will be filed on your behalf on September 15, 2026.",
+  ).should("be.visible");
+  cy.get("@gtag").should(
+    "have.been.calledWith",
+    "event",
+    "autofile_direct_deposit",
+    Cypress.sinon.match.any,
+  );
+  cy.contains("p", "SSN/ITIN: ***-**-").should("be.visible");
+  cy.contains("p", MOCK_SSN.slice(-4)).should("be.visible");
+  cy.contains("p", "ZIP Code:").should("be.visible");
+  cy.contains("p", MOCK_ZIP).should("be.visible");
+  cy.contains("p", "Tax Year: 2025").should("be.visible");
+  cy.contains("p", "Payment Type: Direct Deposit").should("be.visible");
+  for (const faq of AnchorAutofileDirectDepositFaqContent) {
+    cy.contains("button", faq.title as string).click();
+    cy.get(`div[id="${faq.id}"]`).should("be.visible");
+    cy.get("@gtag").should(
+      "have.been.calledWith",
+      "event",
+      `${faq.id}_opened`,
+      Cypress.sinon.match.any,
+    );
+    cy.contains("button", faq.title as string).click();
+    cy.get(`div[id="${faq.id}"]`).should("not.be.visible");
+  }
+});

--- a/webapp/cypress/e2e/autofile.cy.ts
+++ b/webapp/cypress/e2e/autofile.cy.ts
@@ -18,10 +18,7 @@ it("should route the user to the autofile page when autofile API returns true wi
     fixture: "autofile_api_check.json",
   });
   cy.contains("button", `Check Status`).click();
-  cy.contains(
-    "h1",
-    "A 2025 ANCHOR application will be filed on your behalf on September 15, 2026.",
-  ).should("be.visible");
+  cy.contains("h1", "A 2025 ANCHOR application will be filed on your behalf.").should("be.visible");
   cy.get("@gtag").should(
     "have.been.calledWith",
     "event",
@@ -56,10 +53,7 @@ it("should route the user to the autofile page when autofile API returns true wi
     fixture: "autofile_api_direct_deposit.json",
   });
   cy.contains("button", `Check Status`).click();
-  cy.contains(
-    "h1",
-    "A 2025 ANCHOR application will be filed on your behalf on September 15, 2026.",
-  ).should("be.visible");
+  cy.contains("h1", "A 2025 ANCHOR application will be filed on your behalf.").should("be.visible");
   cy.get("@gtag").should(
     "have.been.calledWith",
     "event",

--- a/webapp/cypress/e2e/landingPage.cy.ts
+++ b/webapp/cypress/e2e/landingPage.cy.ts
@@ -6,6 +6,10 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_not_planned.json",
+  });
 });
 
 it("should allow the user to visit the webpage", () => {

--- a/webapp/cypress/e2e/moreInformationNeeded.cy.ts
+++ b/webapp/cypress/e2e/moreInformationNeeded.cy.ts
@@ -26,6 +26,10 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_not_planned.json",
+  });
 });
 
 it("should display issue flagged warning - upload tax bill", () => {

--- a/webapp/cypress/e2e/paymentInfo.cy.ts
+++ b/webapp/cypress/e2e/paymentInfo.cy.ts
@@ -57,6 +57,10 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_not_planned.json",
+  });
   fillFields();
 });
 

--- a/webapp/cypress/fixtures/autofile_api_check.json
+++ b/webapp/cypress/fixtures/autofile_api_check.json
@@ -1,0 +1,4 @@
+{
+  "autofilePlanned": true,
+  "paymentMethod": "check"
+}

--- a/webapp/cypress/fixtures/autofile_api_direct_deposit.json
+++ b/webapp/cypress/fixtures/autofile_api_direct_deposit.json
@@ -1,0 +1,4 @@
+{
+  "autofilePlanned": true,
+  "paymentMethod": "direct_deposit"
+}

--- a/webapp/cypress/fixtures/autofile_api_not_planned.json
+++ b/webapp/cypress/fixtures/autofile_api_not_planned.json
@@ -1,0 +1,3 @@
+{
+  "autofilePlanned": false
+}


### PR DESCRIPTION
## Link to ticket

This commit resolves #214 

## LLM Disclaimer

- Yes, an LLM was used to debug and fix the SSN validation code in `lambda-anchor-autofile-api`

## What was done?
Mailers have gone out to 1.1M+ taxpayers who are a part of the ANCHOR Autofile population. Taxation has provided us with a list of the taxpayers, and we have populated a static DynamoDB DB with hashed SSN+Zip pairs in PR #213.

This PR adds the `api/autofile` route to the website, so we can proxy the request to our lambda function. It also adds the `/anchor-autofile` route, which is shown to taxpayers who are found in our DynamoDB table. One important feature is that based on whether their planned `paymentType` is `check` or `direct_deposit`, the FAQs for the `anchor-autofile` page change accordingly

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test
- A reviewer can test using non-prod data by going to the following URL: https://214-add-autofile-anchor-webpages.d1fv5gc7ba4m6a.amplifyapp.com/

The following non-prod SSN/Zip pairs can be used to test the new functionality:

Check
```
{
  "ssn": "123456789",
  "zip": "11111"
}
```

Direct Deposit
```
{
  "ssn": "123456789",
  "zip": "12345"
}
```

## Screenshots (for visual changes)
<img width="537" height="747" alt="image" src="https://github.com/user-attachments/assets/ca5d84e8-38b5-4f55-8026-6faa8786f554" />

<img width="522" height="760" alt="image" src="https://github.com/user-attachments/assets/fa5c324d-7fc8-44a9-a3d5-bae477bf9472" />


## Notes
The plan is to remove this feature on Sept 15th, as after that point, taxpayers can no longer correct their autofile status. After this feature is removed, we will return to just using the Status Lookup Lambda.