### PR TITLE
[SHOW] Fix logout button placement

### DIFF
--- a/webapp/app/anchor-autofile/page.tsx
+++ b/webapp/app/anchor-autofile/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
-import Link from "next/link";
 import { ProcessList, ProcessListHeading, ProcessListItem } from "@trussworks/react-uswds";
 import { FaqSection } from "@/components/FaqSection";
 import { PaymentMethod } from "@/components/types";
@@ -34,14 +33,6 @@ const AnchorAutofilePage = () => {
     <main id="main-content">
       <section className="usa-section">
         <div className="grid-container">
-          <div style={{ textAlign: "right" }}>
-            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-                <use href="/img/sprite.svg#logout"></use>
-              </svg>
-              Log out
-            </Link>
-          </div>
           <TaxpayerInfoHeader
             lastFourSsnDigits={lastFourSsnDigits}
             zipCode={zipCode}

--- a/webapp/app/application-received/page.tsx
+++ b/webapp/app/application-received/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
-import Link from "next/link";
 import { ProcessList, ProcessListHeading, ProcessListItem } from "@trussworks/react-uswds";
 import { ApplicationReceivedFaqContent } from "./ApplicationReceivedFaqContent";
 import { FaqSection } from "@/components/FaqSection";
@@ -31,14 +30,6 @@ const ApplicationReceivedPage = () => {
     <main id="main-content">
       <section className="usa-section">
         <div className="grid-container">
-          <div style={{ textAlign: "right" }}>
-            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-                <use href="/img/sprite.svg#logout"></use>
-              </svg>
-              Log out
-            </Link>
-          </div>
           <TaxpayerInfoHeader lastFourSsnDigits={lastFourSsnDigits} zipCode={zipCode} />
           <div className="margin-top-4">
             <h1 className="font-heading-xl">

--- a/webapp/app/more-information-needed/page.tsx
+++ b/webapp/app/more-information-needed/page.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import { IssueFlaggedType } from "@/components/types";
-import Link from "next/link";
 import { Alert } from "@trussworks/react-uswds";
 import { TaxpayerInfoHeader } from "@/components/TaxpayerInfoHeader";
 
@@ -83,14 +82,6 @@ const MoreInformationNeededPage = () => {
     <main id="main-content">
       <section className="usa-section">
         <div className="grid-container">
-          <div style={{ textAlign: "right" }}>
-            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-                <use href="/img/sprite.svg#logout"></use>
-              </svg>
-              Log out
-            </Link>
-          </div>
           <TaxpayerInfoHeader lastFourSsnDigits={lastFourSsnDigits} zipCode={zipCode} />
           {issueFlagged !== undefined && (
             <Alert type="warning" headingLevel="h2" heading="Additional information needed">

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -3,7 +3,6 @@
 import { JSX, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
-import Link from "next/link";
 import { Table } from "@trussworks/react-uswds";
 import { formatDate } from "../utils/formatDate";
 import { PaymentInfoFaqContent } from "@/app/payment-info/PaymentInfoFaqContent";
@@ -102,14 +101,6 @@ const PaymentInfoPage = () => {
     <main id="main-content">
       <section className="usa-section">
         <div className="grid-container">
-          <div style={{ textAlign: "right" }}>
-            <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
-              <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
-                <use href="/img/sprite.svg#logout"></use>
-              </svg>
-              Log out
-            </Link>
-          </div>
           <TaxpayerInfoHeader lastFourSsnDigits={lastFourSsnDigits} zipCode={zipCode} />
           <div className="margin-top-4">
             <h1 className="font-heading-xl">You are eligible for benefits</h1>

--- a/webapp/components/LogoutButton.tsx
+++ b/webapp/components/LogoutButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+
+const PAGES_WITHOUT_LOGOUT = ["/"];
+
+export const LogoutButton = () => {
+  const pathname = usePathname();
+
+  const shouldShowButton = !PAGES_WITHOUT_LOGOUT.includes(pathname);
+
+  if (!shouldShowButton) return null;
+
+  return (
+    <>
+      <div className="grid-container">
+        <div className="text-right">
+          <Link className="usa-button usa-button--outline margin-right-3 margin-top-3" href="/">
+            <svg focusable="false" role="img" width="20" height="20" fill="#005ea2">
+              <use href="/img/sprite.svg#logout"></use>
+            </svg>
+            Log out
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/webapp/components/StatusCheckerHeader.tsx
+++ b/webapp/components/StatusCheckerHeader.tsx
@@ -1,5 +1,6 @@
 import { Logo } from "@trussworks/react-uswds";
 import { Alert } from "@trussworks/react-uswds";
+import { LogoutButton } from "./LogoutButton";
 
 /** Property Tax Relief Status Checker and logo */
 export const StatusCheckerHeader = () => (
@@ -9,6 +10,7 @@ export const StatusCheckerHeader = () => (
         <strong>This website is in beta.</strong> This means it is actively being worked on with new
         features coming soon.
       </Alert>
+      <LogoutButton />
       <div className="grid-container">
         <div className="tablet:grid-col-6 padding-top-8">
           <Logo

--- a/webapp/cypress/e2e/landingPage.cy.ts
+++ b/webapp/cypress/e2e/landingPage.cy.ts
@@ -16,6 +16,10 @@ it("should allow the user to visit the webpage", () => {
   cy.contains("h1", "Track your 2025 property tax relief application and payment status");
 });
 
+it("should NOT have a logout button", () => {
+  cy.contains("a", "Log out").should("not.exist");
+});
+
 it("should display an error message when the user tries to submit empty fields", () => {
   cy.get(`button[type="submit"]`).click();
   const ssnError = cy.get(`span[id="ssnErrorMessage"]`);


### PR DESCRIPTION
## Link to ticket

This commit resolves #172 

## LLM Disclaimer

- No LLM was used to create this code

## What was done?
- Rebase of @natekep 's work here: https://github.com/newjersey/tax-relief-status-checker/pull/225
  - Move logout button from each page into shared template
  - Create logout button component that renders as `null` on the landing page, but as an `Link` on every other page
- Removed the CSS `textAlign` property in favor of using USWDS `classname="text-right"`

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

There's a question of whether this button should be a Link (it takes the user to the home page) or a Button (it is an action).

## Steps to test

- Review each of the pages, validate that logout button now appears in header instead of in middle of page

## Screenshots (for visual changes)

- Before
<img width="852" height="706" alt="image" src="https://github.com/user-attachments/assets/dbc13f68-3a19-42be-8acc-ac3a9c06aa0d" />

- After
<img width="999" height="707" alt="image" src="https://github.com/user-attachments/assets/6e21a093-29d7-4e0c-a8ba-f3d787dba3a5" />


## Notes
Pre-factor PR https://github.com/newjersey/tax-relief-status-checker/pull/245 ensures that the logout button will not appear when user goes to a page that does not exist.