### PR TITLE
[SHIP] Content fixes

### DIFF
--- a/webapp/app/LandingPageFaqContent.tsx
+++ b/webapp/app/LandingPageFaqContent.tsx
@@ -22,8 +22,8 @@ export const LandingPageFaqContent: FaqItem[] = [
         <p>Some common reasons this might be happening:</p>
         <ul>
           <li>
-            <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code you filed on your
-            application is different than the one you just entered.
+            <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your application
+            is different than the one you just entered.
           </li>
           <li>
             <strong>It&apos;s too soon</strong>: For online applications, it can take up to three

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -146,7 +146,7 @@ const LandingPage = () => {
             </p>
             <ul>
               <li>
-                <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code you filed on your
+                <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your
                 application is different than the one you just entered.
               </li>
               <li>
@@ -234,7 +234,7 @@ const LandingPage = () => {
                     aria-invalid={errors.ssn ? "true" : "false"}
                     aria-describedby={errors.ssn ? "ssnErrorMessage" : undefined}
                     {...register("ssn", {
-                      required: "This question is required",
+                      required: "SSN or ITIN is required",
                       pattern: {
                         value: /\d{3}-\d{2}-\d{4}/,
                         message: "SSN or ITIN number entered must have nine digits",
@@ -262,10 +262,10 @@ const LandingPage = () => {
                     aria-invalid={errors.zipCode ? "true" : "false"}
                     aria-describedby={errors.zipCode ? "zipCodeErrorMessage" : undefined}
                     {...register("zipCode", {
-                      required: "This question is required",
+                      required: "ZIP code is required",
                       minLength: {
                         value: 5,
-                        message: "Zip code must have five digits",
+                        message: "ZIP code must have five digits",
                       },
                     })}
                   />

--- a/webapp/cypress/e2e/landingPage.cy.ts
+++ b/webapp/cypress/e2e/landingPage.cy.ts
@@ -22,18 +22,16 @@ it("should NOT have a logout button", () => {
 
 it("should display an error message when the user tries to submit empty fields", () => {
   cy.get(`button[type="submit"]`).click();
-  const ssnError = cy.get(`span[id="ssnErrorMessage"]`);
-  const zipError = cy.get(`span[id="zipCodeErrorMessage"]`);
-  ssnError.should("be.visible");
-  ssnError.should("contain.text", "This question is required");
-  zipError.should("be.visible");
-  zipError.should("contain.text", "This question is required");
+  cy.get(`span[id="ssnErrorMessage"]`).should("be.visible");
+  cy.get(`span[id="ssnErrorMessage"]`).should("contain.text", "SSN or ITIN is required");
+  cy.get(`span[id="zipCodeErrorMessage"]`).should("be.visible");
+  cy.get(`span[id="zipCodeErrorMessage"]`).should("contain.text", "ZIP code is required");
 });
 
 it("displays SSN error messages properly", () => {
   cy.get(`button[type="submit"]`).click();
   cy.get(`#ssnErrorMessage`).should("be.visible");
-  cy.get(`#ssnErrorMessage`).should("contain.text", "This question is required");
+  cy.get(`#ssnErrorMessage`).should("contain.text", "SSN or ITIN is required");
 
   fillField("ssn", "1");
   cy.contains("button", `Check Status`).click();
@@ -50,12 +48,12 @@ it("displays SSN error messages properly", () => {
 it("displays Zip Code error messages properly", () => {
   cy.get(`button[type="submit"]`).click();
   cy.get(`#zipCodeErrorMessage`).should("be.visible");
-  cy.get(`#zipCodeErrorMessage`).should("contain.text", "This question is required");
+  cy.get(`#zipCodeErrorMessage`).should("contain.text", "ZIP code is required");
 
   fillField("zipCode", "1");
   cy.contains("button", `Check Status`).click();
   cy.get(`#zipCodeErrorMessage`).should("be.visible");
-  cy.get(`#zipCodeErrorMessage`).should("contain.text", "Zip code must have five digits");
+  cy.get(`#zipCodeErrorMessage`).should("contain.text", "ZIP code must have five digits");
 
   fillField("zipCode", "2345");
   cy.get("#zipCodeErrorMessage").should("not.exist");


### PR DESCRIPTION
## Link to ticket

#258 and #237 

## LLM Disclaimer

- An LLM helped debug the issue with cypress selector

## What was done?

- Remove the word "you" in content since a filer may have been auto-filed #258 
- Give more specific error messages #237 
- Bonus: fix "Zip code" in the error message

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test
`npm run test`
`npm run dev && npx run cypress`

## Screenshots (for visual changes)

- Before
<img width="586" height="705" alt="image" src="https://github.com/user-attachments/assets/68b1538f-cd3f-4927-b8ed-e74e827e8c43" />

<img width="998" height="385" alt="image" src="https://github.com/user-attachments/assets/177a319e-09f9-4b76-b09a-7e2813e33d46" />


- After
<img width="549" height="694" alt="image" src="https://github.com/user-attachments/assets/691d68e0-c422-4b3d-bbf8-c3ddacb11249" />

<img width="994" height="381" alt="image" src="https://github.com/user-attachments/assets/50648e87-d91d-4bfc-83b7-64321e53a6d8" />



## Notes
No
