### PR TITLE
[SHOW] Disable showing ANCHOR payments

### DIFF
--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -57,7 +57,7 @@ const checkAutofile = async (params: {
 };
 
 const determineRoute = (record: StatusRecord): string => {
-  const hasPaymentSentTransaction = [...record.anchor, ...record.ptr].some(
+  const hasPaymentSentTransaction = [...record.ptr].some(
     (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
   );
 

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -95,7 +95,7 @@ const PaymentInfoPage = () => {
     return null;
   }
 
-  const { lastFourSsnDigits, zipCode, anchor, ptr } = dataStore;
+  const { lastFourSsnDigits, zipCode, ptr } = dataStore;
 
   return (
     <main id="main-content">

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -118,10 +118,6 @@ const PaymentInfoPage = () => {
                 if (ptr.length === 0) return null;
                 return showProgramTransactions(ptr, TaxProgram.PTR);
               })()}
-              {(() => {
-                if (anchor.length === 0) return null;
-                return showProgramTransactions(anchor, TaxProgram.ANCHOR);
-              })()}
             </tbody>
           </Table>
           <p>

--- a/webapp/cypress/e2e/applicationReceived.cy.ts
+++ b/webapp/cypress/e2e/applicationReceived.cy.ts
@@ -1,4 +1,5 @@
 import { fillFields, MOCK_SSN, MOCK_ZIP } from "./utils";
+import payment_sent_transaction from "../fixtures/payment_sent_transaction.json";
 
 const applicationReceivedAssertions = () => {
   cy.url().should("include", "/application-received");
@@ -66,5 +67,32 @@ it("should display application found page if records has an object, but no trans
   });
   cy.contains("button", `Check Status`).click();
 
+  applicationReceivedAssertions();
+});
+
+it("displays application found page if record has anchor CHECK", () => {
+  cy.fixture("v2_api_found_records.json").then((resp) => {
+    resp.records[0].ptr[0] = { status: "processing" };
+    resp.records[0].anchor[0] = payment_sent_transaction;
+    cy.intercept("POST", "/api/status", {
+      statusCode: 200,
+      body: resp,
+    });
+  });
+  cy.contains("button", `Check Status`).click();
+  applicationReceivedAssertions();
+});
+
+it("displays application found page if record has anchor DIRECT DEPOSIT", () => {
+  cy.fixture("v2_api_found_records.json").then((resp) => {
+    resp.records[0].ptr[0] = { status: "processing" };
+    resp.records[0].anchor[0] = payment_sent_transaction;
+    resp.records[0].anchor[0].payment_details.method = "direct_deposit";
+    cy.intercept("POST", "/api/status", {
+      statusCode: 200,
+      body: resp,
+    });
+  });
+  cy.contains("button", `Check Status`).click();
   applicationReceivedAssertions();
 });

--- a/webapp/cypress/e2e/paymentInfo.cy.ts
+++ b/webapp/cypress/e2e/paymentInfo.cy.ts
@@ -119,35 +119,6 @@ it("displays payments page if records has senior freeze DIRECT DEPOSIT", () => {
   paymentInfoAssertions(TaxProgram.PTR, PaymentType.DIRECT_DEPOSIT, mockDate, mockAmount);
 });
 
-it("displays payments page if records has anchor CHECK", () => {
-  cy.fixture("v2_api_found_records.json").then((resp) => {
-    resp.records[0].ptr[0] = { status: "processing" };
-    resp.records[0].anchor[0] = payment_sent_transaction;
-    cy.intercept("POST", "/api/status", {
-      statusCode: 200,
-      body: resp,
-    });
-  });
-  cy.contains("button", `Check Status`).click();
-  cy.url().should("include", "/payment-info");
-  paymentInfoAssertions(TaxProgram.ANCHOR, PaymentType.CHECK, mockDate, mockAmount);
-});
-
-it("displays payments page if records has anchor DIRECT DEPOSIT", () => {
-  cy.fixture("v2_api_found_records.json").then((resp) => {
-    resp.records[0].ptr[0] = { status: "processing" };
-    resp.records[0].anchor[0] = payment_sent_transaction;
-    resp.records[0].anchor[0].payment_details.method = "direct_deposit";
-    cy.intercept("POST", "/api/status", {
-      statusCode: 200,
-      body: resp,
-    });
-  });
-  cy.contains("button", `Check Status`).click();
-  cy.url().should("include", "/payment-info");
-  paymentInfoAssertions(TaxProgram.ANCHOR, PaymentType.DIRECT_DEPOSIT, mockDate, mockAmount);
-});
-
 it("displays the first check sent if multiple PTR transactions are payment_sent", () => {
   cy.fixture("v2_api_found_records.json").then((resp) => {
     resp.records[0].ptr[0] = payment_sent_transaction;
@@ -163,27 +134,7 @@ it("displays the first check sent if multiple PTR transactions are payment_sent"
   paymentInfoAssertions(TaxProgram.PTR, PaymentType.DIRECT_DEPOSIT, mockEarlyDate, mockEarlyAmount);
 });
 
-it("displays the first check sent if multiple ANCHOR transactions are payment_sent", () => {
-  cy.fixture("v2_api_found_records.json").then((resp) => {
-    resp.records[0].ptr[0] = { status: "processing" };
-    resp.records[0].anchor[0] = payment_sent_transaction;
-    resp.records[0].anchor[0] = earlier_transaction;
-    cy.intercept("POST", "/api/status", {
-      statusCode: 200,
-      body: resp,
-    });
-  });
-  cy.contains("button", `Check Status`).click();
-  cy.url().should("include", "/payment-info");
-  paymentInfoAssertions(
-    TaxProgram.ANCHOR,
-    PaymentType.DIRECT_DEPOSIT,
-    mockEarlyDate,
-    mockEarlyAmount,
-  );
-});
-
-it("displays first check and update payment across every payment category", () => {
+it("displays first check and update payment for PTR but not for ANCHOR or STAYNJ", () => {
   cy.intercept("POST", "/api/status", {
     statusCode: 200,
     fixture: "update_payment_records.json",
@@ -192,6 +143,14 @@ it("displays first check and update payment across every payment category", () =
   cy.url().should("include", "/payment-info");
   paymentInfoAssertions(TaxProgram.PTR, PaymentType.DIRECT_DEPOSIT, "07/16/2026", 125);
   paymentInfoAssertions(TaxProgram.PTR, PaymentType.ADJUSTED, "07/17/2026", 5);
-  paymentInfoAssertions(TaxProgram.ANCHOR, PaymentType.DIRECT_DEPOSIT, "09/06/2026", 377.56);
-  paymentInfoAssertions(TaxProgram.ANCHOR, PaymentType.ADJUSTED, "10/06/2026", 1750);
+
+  cy.contains("td", TaxProgram.ANCHOR).should("not.exist");
+  cy.contains("td", "Direct deposit issued on 09/06/2026").should("not.exist");
+  cy.contains("td", "1750.00").should("not.exist");
+
+  cy.contains("td", TaxProgram.ANCHOR).should("not.exist");
+  cy.contains("td", `Your benefit amount was adjusted. A check was sent on 10/6/2026`).should(
+    "not.exist",
+  );
+  cy.contains("td", `377.56`).should("not.exist");
 });


### PR DESCRIPTION
## Link to ticket

This commit resolves #264 

## LLM Disclaimer

- An LLM helped me fix my test assertions, from `not.be.visible` to `not.exist`

## What was done?

- The database will contain `payment_sent` transactions starting Monday, Aug 31. With the existing logic, this response from our DB would bring users to the `payment-info` page and show them ANCHOR transactions.
- However, Taxation does not plan on mailing checks until Sept 15. In order to resident confusion, #264 was created in order to not show residents their ANCHOR payments, even if the DB says they have been sent.

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test

- The new Cypress tests cover this case
  - `npm run dev` && `npx cypress run`

## Screenshots (for visual changes)

- Before
- After

## Notes
Normally we'd do this with a feature flag. Since this was a last minute request (ticket created at 12:30p today) that needed to get done before EOD today as I am the only engineer on the project, and I will be OOO tomorrow and Friday, I opted to do this with a code change that we can `git revert` on Sept 15th.