### PR TITLE
[SHOW] - add stay NJ payments

### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -23,3 +23,5 @@ jobs:
           build: npx next build
           start: npx next start
           wait-on: "http://localhost:3000/"
+        env:
+          NEXT_PUBLIC_ENABLE_STAY: "true"

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -57,7 +57,7 @@ const checkAutofile = async (params: {
 };
 
 const determineRoute = (record: StatusRecord): string => {
-  const hasPaymentSentTransaction = [...record.ptr].some(
+  const hasPaymentSentTransaction = [...record.ptr, ...record.stay_nj].some(
     (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
   );
 

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -57,9 +57,17 @@ const checkAutofile = async (params: {
 };
 
 const determineRoute = (record: StatusRecord): string => {
-  const hasPaymentSentTransaction = [...record.ptr, ...record.stay_nj].some(
+  let hasPaymentSentTransaction = [...record.ptr].some(
     (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
   );
+
+  if (process.env.NEXT_PUBLIC_ENABLE_STAY) {
+    hasPaymentSentTransaction =
+      hasPaymentSentTransaction ||
+      [...record.stay_nj].some(
+        (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
+      );
+  }
 
   if (hasPaymentSentTransaction) {
     return "/payment-info";

--- a/webapp/app/payment-info/page.test.tsx
+++ b/webapp/app/payment-info/page.test.tsx
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   getEarliestTransaction,
   showProgramTransactions,
-  showEarliestTransaction,
+  showTransactionRow,
   showUpdatedTransaction,
 } from "./page";
 import { render } from "@testing-library/react";
@@ -91,7 +91,7 @@ describe("getEarliestTransaction", () => {
 
 describe("showEarliestTransaction", () => {
   it("shows correct message when method is check", () => {
-    const result = showEarliestTransaction(payment_sent_transaction, TaxProgram.ANCHOR);
+    const result = showTransactionRow(payment_sent_transaction, TaxProgram.ANCHOR);
     const html = renderToStaticMarkup(result);
     checkTransactionInfo(
       html,
@@ -105,7 +105,7 @@ describe("showEarliestTransaction", () => {
   it("shows correct message when method is direct deposit", () => {
     const transaction = payment_sent_transaction;
     transaction.payment_details.method = PaymentMethod.DIRECT_DEPOSIT;
-    const result = showEarliestTransaction(transaction, TaxProgram.ANCHOR);
+    const result = showTransactionRow(transaction, TaxProgram.ANCHOR);
     const html = renderToStaticMarkup(result);
     checkTransactionInfo(
       html,
@@ -117,7 +117,7 @@ describe("showEarliestTransaction", () => {
   });
 
   it("returns nothing if there is no payment_details", () => {
-    expect(showEarliestTransaction(error_payment_sent_transaction, TaxProgram.ANCHOR)).toBeNull;
+    expect(showTransactionRow(error_payment_sent_transaction, TaxProgram.ANCHOR)).toBeNull;
   });
 });
 

--- a/webapp/app/payment-info/page.test.tsx
+++ b/webapp/app/payment-info/page.test.tsx
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   getEarliestTransaction,
   showProgramTransactions,
-  showTransactionRow,
+  showRegularTransaction,
   showUpdatedTransaction,
 } from "./page";
 import { render } from "@testing-library/react";
@@ -91,7 +91,7 @@ describe("getEarliestTransaction", () => {
 
 describe("showEarliestTransaction", () => {
   it("shows correct message when method is check", () => {
-    const result = showTransactionRow(payment_sent_transaction, TaxProgram.ANCHOR);
+    const result = showRegularTransaction(payment_sent_transaction, TaxProgram.ANCHOR);
     const html = renderToStaticMarkup(result);
     checkTransactionInfo(
       html,
@@ -105,7 +105,7 @@ describe("showEarliestTransaction", () => {
   it("shows correct message when method is direct deposit", () => {
     const transaction = payment_sent_transaction;
     transaction.payment_details.method = PaymentMethod.DIRECT_DEPOSIT;
-    const result = showTransactionRow(transaction, TaxProgram.ANCHOR);
+    const result = showRegularTransaction(transaction, TaxProgram.ANCHOR);
     const html = renderToStaticMarkup(result);
     checkTransactionInfo(
       html,
@@ -117,7 +117,7 @@ describe("showEarliestTransaction", () => {
   });
 
   it("returns nothing if there is no payment_details", () => {
-    expect(showTransactionRow(error_payment_sent_transaction, TaxProgram.ANCHOR)).toBeNull;
+    expect(showRegularTransaction(error_payment_sent_transaction, TaxProgram.ANCHOR)).toBeNull;
   });
 });
 

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -31,7 +31,7 @@ export const getEarliestTransaction = (transactions: Transaction[]) => {
   return earliestTransaction;
 };
 
-export const showEarliestTransaction = (transaction: Transaction, taxProgram: TaxProgram) => {
+export const showTransactionRow = (transaction: Transaction, taxProgram: TaxProgram) => {
   if (!transaction?.payment_details) return null;
   return (
     <tr>
@@ -73,7 +73,7 @@ export const showProgramTransactions = (transactions: Transaction[], taxProgram:
 
   return (
     <>
-      {showEarliestTransaction(earliest, taxProgram)}
+      {showTransactionRow(earliest, taxProgram)}
       {remainingTransactions.map((transaction) => showUpdatedTransaction(transaction, taxProgram))}
     </>
   );
@@ -95,7 +95,7 @@ const PaymentInfoPage = () => {
     return null;
   }
 
-  const { lastFourSsnDigits, zipCode, ptr } = dataStore;
+  const { lastFourSsnDigits, zipCode, ptr, stay_nj } = dataStore;
 
   return (
     <main id="main-content">
@@ -117,6 +117,12 @@ const PaymentInfoPage = () => {
               {(() => {
                 if (ptr.length === 0) return null;
                 return showProgramTransactions(ptr, TaxProgram.PTR);
+              })()}
+              {(() => {
+                if (stay_nj.length === 0) return null;
+                for (const transaction of stay_nj) {
+                  return showTransactionRow(transaction, TaxProgram.STAY_NJ);
+                }
               })()}
             </tbody>
           </Table>

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -120,9 +120,9 @@ const PaymentInfoPage = () => {
               })()}
               {(() => {
                 if (stay_nj.length === 0) return null;
-                for (const transaction of stay_nj) {
-                  return showTransactionRow(transaction, TaxProgram.STAY_NJ);
-                }
+                return stay_nj.map((transaction) =>
+                  showTransactionRow(transaction, TaxProgram.STAY_NJ),
+                );
               })()}
             </tbody>
           </Table>

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -31,7 +31,7 @@ export const getEarliestTransaction = (transactions: Transaction[]) => {
   return earliestTransaction;
 };
 
-export const showTransactionRow = (transaction: Transaction, taxProgram: TaxProgram) => {
+export const showRegularTransaction = (transaction: Transaction, taxProgram: TaxProgram) => {
   if (!transaction?.payment_details) return null;
   return (
     <tr>
@@ -66,17 +66,25 @@ export const showUpdatedTransaction = (
 };
 
 export const showProgramTransactions = (transactions: Transaction[], taxProgram: TaxProgram) => {
-  const earliest = getEarliestTransaction(transactions);
-  if (!earliest?.payment_details) return null;
+  if (taxProgram === TaxProgram.PTR || taxProgram === TaxProgram.ANCHOR) {
+    const earliest = getEarliestTransaction(transactions);
+    if (!earliest?.payment_details) return null;
 
-  const remainingTransactions = transactions.filter((transaction) => transaction !== earliest);
+    const remainingTransactions = transactions.filter((transaction) => transaction !== earliest);
 
-  return (
-    <>
-      {showTransactionRow(earliest, taxProgram)}
-      {remainingTransactions.map((transaction) => showUpdatedTransaction(transaction, taxProgram))}
-    </>
-  );
+    return (
+      <>
+        {showRegularTransaction(earliest, taxProgram)}
+        {remainingTransactions.map((transaction) =>
+          showUpdatedTransaction(transaction, taxProgram),
+        )}
+      </>
+    );
+  } else if (taxProgram === TaxProgram.STAY_NJ) {
+    return transactions.map((transaction) =>
+      showRegularTransaction(transaction, TaxProgram.STAY_NJ),
+    );
+  }
 };
 
 const PaymentInfoPage = () => {
@@ -120,9 +128,7 @@ const PaymentInfoPage = () => {
               })()}
               {(() => {
                 if (stay_nj.length === 0) return null;
-                return stay_nj.map((transaction) =>
-                  showTransactionRow(transaction, TaxProgram.STAY_NJ),
-                );
+                return showProgramTransactions(stay_nj, TaxProgram.STAY_NJ);
               })()}
             </tbody>
           </Table>

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -127,7 +127,8 @@ const PaymentInfoPage = () => {
                 return showProgramTransactions(ptr, TaxProgram.PTR);
               })()}
               {(() => {
-                if (!process.env.NEXT_PUBLIC_ENABLE_STAY || stay_nj.length === 0) return null;
+                if (!(process.env.NEXT_PUBLIC_ENABLE_STAY == "true") || stay_nj.length === 0)
+                  return null;
                 return showProgramTransactions(stay_nj, TaxProgram.STAY_NJ);
               })()}
             </tbody>

--- a/webapp/app/payment-info/page.tsx
+++ b/webapp/app/payment-info/page.tsx
@@ -127,7 +127,7 @@ const PaymentInfoPage = () => {
                 return showProgramTransactions(ptr, TaxProgram.PTR);
               })()}
               {(() => {
-                if (stay_nj.length === 0) return null;
+                if (!process.env.NEXT_PUBLIC_ENABLE_STAY || stay_nj.length === 0) return null;
                 return showProgramTransactions(stay_nj, TaxProgram.STAY_NJ);
               })()}
             </tbody>

--- a/webapp/app/utils/determineRoute.test.ts
+++ b/webapp/app/utils/determineRoute.test.ts
@@ -21,6 +21,26 @@ describe("determineRoute", () => {
     expect(determineRoute(record)).toBe("/payment-info");
   });
 
+  it("routes a user to payment info when record has Stay NJ payment sent when feature flag is true", () => {
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_STAY", "true");
+    const record = buildStatusRecord({
+      stay_nj: [{ status: TransactionStatus.PAYMENT_SENT }],
+    });
+
+    expect(determineRoute(record)).toBe("/payment-info");
+    vi.unstubAllEnvs();
+  });
+
+  it("routes a user to application-received when record has Stay NJ payment sent when feature flag is false", () => {
+    vi.stubEnv("NEXT_PUBLIC_ENABLE_STAY", "false");
+    const record = buildStatusRecord({
+      stay_nj: [{ status: TransactionStatus.PAYMENT_SENT }],
+    });
+
+    expect(determineRoute(record)).toBe("/application-received");
+    vi.unstubAllEnvs();
+  });
+
   it("routes a user to more-information-needed when record has a flagged issue", () => {
     const record = buildStatusRecord({
       ptr: [{ status: TransactionStatus.ISSUE_FLAGGED, review_category: "SVR" }],

--- a/webapp/app/utils/determineRoute.ts
+++ b/webapp/app/utils/determineRoute.ts
@@ -4,7 +4,11 @@ import { setIssueFlagged } from "./setIssueFlagged";
 
 /** Determines the route to navigate to based on the status record's transaction data. */
 export const determineRoute = (record: StatusRecord): string => {
-  const hasPaymentSentTransaction = [...record.ptr].some(
+  let recordsToCheck = [...record.ptr];
+  if (process.env.NEXT_PUBLIC_ENABLE_STAY) {
+    recordsToCheck.push(...record.stay_nj);
+  }
+  const hasPaymentSentTransaction = recordsToCheck.some(
     (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
   );
 

--- a/webapp/app/utils/determineRoute.ts
+++ b/webapp/app/utils/determineRoute.ts
@@ -5,7 +5,7 @@ import { setIssueFlagged } from "./setIssueFlagged";
 /** Determines the route to navigate to based on the status record's transaction data. */
 export const determineRoute = (record: StatusRecord): string => {
   let recordsToCheck = [...record.ptr];
-  if (process.env.NEXT_PUBLIC_ENABLE_STAY) {
+  if (process.env.NEXT_PUBLIC_ENABLE_STAY == "true") {
     recordsToCheck.push(...record.stay_nj);
   }
   const hasPaymentSentTransaction = recordsToCheck.some(

--- a/webapp/cypress/e2e/paymentInfo.cy.ts
+++ b/webapp/cypress/e2e/paymentInfo.cy.ts
@@ -154,3 +154,40 @@ it("displays first check and update payment for PTR but not for ANCHOR or STAYNJ
   );
   cy.contains("td", `377.56`).should("not.exist");
 });
+
+it("displays payments page if records has stay NJ CHECK", () => {
+  cy.fixture("stay_record").then((resp) => {
+    resp.records[0].stay_nj[1] = null;
+    cy.intercept("POST", "/api/status", {
+      statusCode: 200,
+      body: resp,
+    });
+  });
+  cy.contains("button", `Check Status`).click();
+  cy.url().should("include", "/payment-info");
+  paymentInfoAssertions(
+    TaxProgram.STAY_NJ,
+    PaymentType.CHECK,
+    formatDate("1/2/2027 00:00:00"),
+    mockAmount,
+  );
+});
+
+it("displays payments page if records has stay NJ DIRECT DEPOSIT", () => {
+  cy.fixture("stay_record").then((resp) => {
+    resp.records[0].stay_nj[0].paymentType = PaymentType.DIRECT_DEPOSIT;
+    resp.records[0].stay_nj[1] = null;
+    cy.intercept("POST", "/api/status", {
+      statusCode: 200,
+      body: resp,
+    });
+  });
+  cy.contains("button", `Check Status`).click();
+  cy.url().should("include", "/payment-info");
+  paymentInfoAssertions(
+    TaxProgram.STAY_NJ,
+    PaymentType.CHECK,
+    formatDate("1/2/2027 00:00:00"),
+    mockAmount,
+  );
+});

--- a/webapp/cypress/e2e/paymentInfo.cy.ts
+++ b/webapp/cypress/e2e/paymentInfo.cy.ts
@@ -175,7 +175,7 @@ it("displays payments page if records has stay NJ CHECK", () => {
 
 it("displays payments page if records has stay NJ DIRECT DEPOSIT", () => {
   cy.fixture("stay_record").then((resp) => {
-    resp.records[0].stay_nj[0].paymentType = PaymentType.DIRECT_DEPOSIT;
+    resp.records[0].stay_nj[0].payment_details.method = PaymentType.DIRECT_DEPOSIT;
     resp.records[0].stay_nj[1] = null;
     cy.intercept("POST", "/api/status", {
       statusCode: 200,
@@ -186,8 +186,32 @@ it("displays payments page if records has stay NJ DIRECT DEPOSIT", () => {
   cy.url().should("include", "/payment-info");
   paymentInfoAssertions(
     TaxProgram.STAY_NJ,
-    PaymentType.CHECK,
+    PaymentType.DIRECT_DEPOSIT,
     formatDate("1/2/2027 00:00:00"),
+    mockAmount,
+  );
+});
+
+it("displays both payments as regular if records has 2 stay NJ transaction in the same quarter", () => {
+  cy.fixture("stay_record").then((resp) => {
+    resp.records[0].stay_nj[0].payment_details.method = PaymentType.DIRECT_DEPOSIT;
+    cy.intercept("POST", "/api/status", {
+      statusCode: 200,
+      body: resp,
+    });
+  });
+  cy.contains("button", `Check Status`).click();
+  cy.url().should("include", "/payment-info");
+  paymentInfoAssertions(
+    TaxProgram.STAY_NJ,
+    PaymentType.DIRECT_DEPOSIT,
+    formatDate("1/2/2027 00:00:00"),
+    mockAmount,
+  );
+  paymentInfoAssertions(
+    TaxProgram.STAY_NJ,
+    PaymentType.CHECK,
+    formatDate("1/6/2027 00:00:00"),
     mockAmount,
   );
 });


### PR DESCRIPTION
## Link to ticket

This commit resolves [280](https://github.com/newjersey/tax-relief-status-checker/issues/280#issue-5296081933)

## LLM Disclaimer

- No LLM was used to write this code

## What was done?

- A resident is now able to view their Stay NJ payments, however we are no longer showing a transaction as an "Update" payment, and instead they will all be considered "Regular". (see Notes)
- Changed name of `showEarliestTransaction` to `showTransactionRow` because it is no longer just showing the earliest transaction, and will be used to display each Stay NJ transaction. 

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test

- Download code locally and run `NEXT_PUBLIC_ENABLE_STAY="true" npm run dev` and `npm run cypress`

## Screenshots (for visual changes)

- Before

<img width="687" height="483" alt="Screenshot 2026-09-02 at 4 33 33 PM" src="https://github.com/user-attachments/assets/eb957574-c90e-4ae4-8e4d-dafe0848a00c" />

- After

<img width="797" height="409" alt="Screenshot 2026-09-02 at 4 32 16 PM" src="https://github.com/user-attachments/assets/acf72b2f-dcb1-4805-ab6a-f9bf93ef6366" />


## Notes
@emtwelp and I had a meeting to discuss the date formatting for the checks in the TAX db. During our conversation the following scenario came up. In the case where a person receives a check near the end of the associated quarter range, and then that person gets an update payment with a date in the following quarter, that payment would be considered a regular payment instead of an update payment (Ex: Resident received Q1 check on 4/30, updated Q1 check on 5/2, and Q2 check on 5/5. Application would display the two Q1 payments as a regular payments and the Q2 payment as an updated payment to the second Q1 check). The current state of the DB does not have a way to differentiate between regular and update without using the date of the check. We decided that for Stay NJ payments, every check received will be treated as a regular payment and get displayed as such. Two considerations made going into that decision: 1. Not that common that someone will receive an updated Stay payment, and 2. This allows for subsequent application years to not have to worry about the date range for quarterly payments changing, and can be used as is for later development. We are also considering adding a column to the db to be able to differentiate the updated payments. 

Info on what is a "Regular" vs "Update" payment:

If a Stay payment is the first within each of the following time periods, it should be considered a "regular" payment and use this copy: "Check sent on [DATE] or "Direct deposit made on [DATE].":
- February 1, 2027 - April 30, 2027
- May 1, 2027 - July 31, 2027
- August 1, 2027 - October 31, 2027
- November 1, 2027 - January 31, 2028

If a Stay payment is NOT the first within the time period, it should be considered an "update" payment and use this copy: "Your benefit amount was adjusted. Another check was sent on [DATE]." Note: update payments are always sent by check, so there is no direct deposit version of this content.