### PR TITLE
286 - change autofile api ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,15 +115,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
-      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.3.tgz",
+      "integrity": "sha512-98We1QWfin9vtuuQtNFhIIAEWb8CreyYTAP0Vn8HqSBoNiFJM9nZgifJeQawT9Wq0NX1HCNFlxCyTccIrK1PSA==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.20.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.20.0.tgz",
-      "integrity": "sha512-ts2dVBi0VUXOLKcqyLYsHUWYpwGPFd+xm4q+6Y4jjP8orwodjRi2mJrmpy9b0gHnbv8e/hFnmEbqrD0bBJOnPA==",
+      "version": "54.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.22.0.tgz",
+      "integrity": "sha512-vsOuFw4+UC5+m2YZLhCecxt6wibIOmXCszA4uXaBcde2tZWx06vp1z5ByHnJeLS83A11XpAkW/TiIBGCL6jxuQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
-      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
       "devOptional": true,
       "funding": [
         {
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
-      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
       "devOptional": true,
       "funding": [
         {
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -1239,13 +1239,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -1261,20 +1261,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1284,9 +1284,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -1300,9 +1300,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -1316,9 +1316,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -1335,9 +1335,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -1430,9 +1430,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -1449,9 +1449,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -1468,9 +1468,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -1489,13 +1489,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1514,13 +1514,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1539,13 +1539,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -1564,13 +1564,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -1589,13 +1589,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -1614,13 +1614,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -1639,13 +1639,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -1664,17 +1664,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1684,16 +1684,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1722,9 +1722,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1741,9 +1741,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -1967,19 +1967,19 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
-      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
       "devOptional": true,
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       }
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
-      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
       "cpu": [
         "arm"
       ],
@@ -1993,9 +1993,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
-      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
       "cpu": [
         "arm64"
       ],
@@ -2009,9 +2009,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
-      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
       "cpu": [
         "arm64"
       ],
@@ -2025,9 +2025,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
-      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
       "cpu": [
         "x64"
       ],
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
-      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
       "cpu": [
         "x64"
       ],
@@ -2057,9 +2057,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
-      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
       "cpu": [
         "arm"
       ],
@@ -2073,9 +2073,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
-      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
       "cpu": [
         "arm64"
       ],
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
-      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
       "cpu": [
         "arm64"
       ],
@@ -2111,9 +2111,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
-      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
       "cpu": [
         "ppc64"
       ],
@@ -2130,9 +2130,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
-      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
       "cpu": [
         "s390x"
       ],
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
-      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
       "cpu": [
         "x64"
       ],
@@ -2168,9 +2168,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
-      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
       "cpu": [
         "x64"
       ],
@@ -2187,9 +2187,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
-      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
       "cpu": [
         "arm64"
       ],
@@ -2203,9 +2203,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
-      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
       "cpu": [
         "arm64"
       ],
@@ -2219,9 +2219,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
-      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
       "cpu": [
         "x64"
       ],
@@ -2310,13 +2310,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
-      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.2",
-        "@smithy/types": "^4.17.2",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2336,13 +2336,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
-      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2377,9 +2377,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
-      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2512,6 +2512,20 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@trussworks/react-uswds": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@trussworks/react-uswds/-/react-uswds-12.0.0.tgz",
@@ -2623,9 +2637,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -2917,7 +2931,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
@@ -3197,9 +3210,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.16.tgz",
-      "integrity": "sha512-H/bNPUFHewJHyCTdjn1n3Pit5+2GmWT6mmeHImPX+8MA9NA6b67jO4gYmi4jTbCJb2otq34KMZnovndDPqJwhQ==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3219,9 +3232,9 @@
       }
     },
     "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+      "integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3321,9 +3334,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001809",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3928,9 +3941,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4215,7 +4228,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -4362,7 +4374,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4680,22 +4691,22 @@
       }
     },
     "node_modules/jsdom/node_modules/tldts": {
-      "version": "7.4.10",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
-      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.12.tgz",
+      "integrity": "sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.10"
+        "tldts-core": "^7.4.12"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/jsdom/node_modules/tldts-core": {
-      "version": "7.4.10",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
-      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+      "integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -4730,7 +4741,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5726,7 +5736,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5736,7 +5745,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6212,16 +6220,15 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6416,13 +6423,13 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
-      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.146.0",
+        "@oxc-project/types": "=0.148.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -6432,21 +6439,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm-eabi": "1.2.5",
-        "@rolldown/binding-android-arm64": "1.2.5",
-        "@rolldown/binding-darwin-arm64": "1.2.5",
-        "@rolldown/binding-darwin-x64": "1.2.5",
-        "@rolldown/binding-freebsd-x64": "1.2.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
-        "@rolldown/binding-linux-arm64-musl": "1.2.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
-        "@rolldown/binding-linux-x64-gnu": "1.2.5",
-        "@rolldown/binding-linux-x64-musl": "1.2.5",
-        "@rolldown/binding-openharmony-arm64": "1.2.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
-        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
       }
     },
     "node_modules/safe-buffer": {
@@ -6478,9 +6485,9 @@
       "license": "MIT"
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.102.0.tgz",
-      "integrity": "sha512-CxfhMwwbQFBCTjGysByvOw4PIOCYZ/jtz9uBU0UR5sfHtQvqqnsNyb1fVCIUsZ7piimxQAwcLV5H3Skj96QiVg==",
+      "version": "1.104.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.104.0.tgz",
+      "integrity": "sha512-xznKQzFnNVNq+GiXPmBXIHLL2rlIoekDxE8HXNKgxXX6bn4fByuHApCmj5Uz+MpVOB154EYCbErztyoEcmnb9Q==",
       "cpu": [
         "x64"
       ],
@@ -6518,7 +6525,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6533,9 +6539,9 @@
       "license": "MIT"
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -6550,31 +6556,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -6951,9 +6957,9 @@
       "license": "MIT"
     },
     "node_modules/systeminformation": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
-      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
+      "version": "5.33.9",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.9.tgz",
+      "integrity": "sha512-mlE+h4IVAA4F4O6sc8NFpClFvsO6yjQ/uVKTq3kmruYqno2CenyDQhyOqRO7q5sl2FZie9c+R3E7pKOBKPDHCA==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -7194,9 +7200,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -7227,7 +7233,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -7337,9 +7342,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "devOptional": true,
       "funding": [
         {
@@ -7357,7 +7362,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7643,7 +7648,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -7688,6 +7692,7 @@
       },
       "devDependencies": {
         "@testing-library/react": "16.3.3",
+        "@testing-library/user-event": "14.6.7",
         "@types/node": "25.9.5",
         "cypress": "15.21.1",
         "jsdom": "30.0.1",

--- a/webapp/app/page.test.tsx
+++ b/webapp/app/page.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import LandingPage, { determineRoute } from "./page";
-import type { StatusRecord } from "./page";
+import LandingPage from "./page";
+import type { StatusRecord } from "@/components/types";
 import { TaxReliefDataProvider } from "@/components/TaxReliefDataProvider";
-import { PaymentMethod, TransactionStatus } from "@/components/types";
+import { PaymentMethod } from "@/components/types";
 import { logGAEvent } from "./utils/analytics";
+import { determineRoute } from "./utils/determineRoute";
 
 const mockPush = vi.fn();
 
@@ -15,6 +16,10 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("./utils/analytics", () => ({
   logGAEvent: vi.fn(),
+}));
+
+vi.mock("./utils/determineRoute", () => ({
+  determineRoute: vi.fn(),
 }));
 
 const renderLandingPage = () =>
@@ -68,7 +73,7 @@ describe("onSubmit handler", () => {
       "/api/status",
       expect.objectContaining({ method: "POST" }),
     );
-    expect(mockPush).toHaveBeenCalledWith("/application-received");
+    expect(determineRoute).toHaveBeenCalledWith(record);
     expect(logGAEvent).toHaveBeenCalledWith("api_200_record_found");
   });
 
@@ -161,32 +166,5 @@ describe("onSubmit handler", () => {
       expect(mockPush).not.toHaveBeenCalled();
       expect(logGAEvent).toHaveBeenCalledWith("autofile_api_error");
     });
-  });
-});
-
-describe("determineRoute", () => {
-  it("routes a user to payment info when record has PTR payment sent", () => {
-    const record = buildStatusRecord({
-      ptr: [{ status: TransactionStatus.PAYMENT_SENT }],
-    });
-
-    expect(determineRoute(record)).toBe("/payment-info");
-  });
-
-  it("routes a user to more-information-needed when record has a flagged issue", () => {
-    const record = buildStatusRecord({
-      ptr: [{ status: TransactionStatus.ISSUE_FLAGGED, review_category: "SVR" }],
-      anchor: [{ status: TransactionStatus.ISSUE_FLAGGED, review_category: "MOD" }],
-    });
-
-    expect(determineRoute(record)).toBe("/more-information-needed");
-  });
-
-  it("routes a user to the application received page when no PTR payment sent and no issue is flagged", () => {
-    const record = buildStatusRecord({
-      ptr: [{ status: TransactionStatus.PROCESSING }],
-    });
-
-    expect(determineRoute(record)).toBe("/application-received");
   });
 });

--- a/webapp/app/page.test.tsx
+++ b/webapp/app/page.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LandingPage, { determineRoute } from "./page";
+import type { StatusRecord } from "./page";
+import { TaxReliefDataProvider } from "@/components/TaxReliefDataProvider";
+import { PaymentMethod, TransactionStatus } from "@/components/types";
+import { logGAEvent } from "./utils/analytics";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("./utils/analytics", () => ({
+  logGAEvent: vi.fn(),
+}));
+
+const renderLandingPage = () =>
+  render(
+    <TaxReliefDataProvider>
+      <LandingPage />
+    </TaxReliefDataProvider>,
+  );
+
+const fillAndSubmitForm = async () => {
+  const user = userEvent.setup();
+  const ssnInput = screen.getByLabelText(/Social Security/i);
+  const zipInput = screen.getByLabelText(/ZIP code/i);
+  const submitButton = screen.getByRole("button", { name: /Check Status/i });
+
+  await user.type(ssnInput, "123456789");
+  await user.type(zipInput, "07001");
+  await user.click(submitButton);
+};
+
+const buildStatusRecord = (overrides?: Partial<StatusRecord>): StatusRecord => ({
+  return_year: "2025",
+  application_date: "2026-03-19T00:00:00.000Z",
+  anchor: [],
+  ptr: [],
+  stay_nj: [],
+  ...overrides,
+});
+
+const mockFetchResponse = (body: unknown, ok = true, status = 200) =>
+  vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  }) as unknown as typeof fetch;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockPush.mockReset();
+});
+
+describe("onSubmit handler", () => {
+  it("calls status API, if record found, sets data store and calls determineRoute", async () => {
+    const record = buildStatusRecord();
+    globalThis.fetch = mockFetchResponse({ records: [record] });
+
+    renderLandingPage();
+    await fillAndSubmitForm();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/status",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(mockPush).toHaveBeenCalledWith("/application-received");
+    expect(logGAEvent).toHaveBeenCalledWith("api_200_record_found");
+  });
+
+  it("calls status API, when response is not 200, it shows the error message", async () => {
+    globalThis.fetch = mockFetchResponse({}, false, 500);
+
+    renderLandingPage();
+    await fillAndSubmitForm();
+
+    expect(
+      screen.getByText(/We are having an issue checking on your application status/i),
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(logGAEvent).toHaveBeenCalledWith("api_error");
+  });
+
+  describe("when status API record not found", () => {
+    const statusResponseNoRecord = { records: [buildStatusRecord({ return_year: "2024" })] };
+
+    it("it calls autofile API, when autofile record is found, sets datastore and routes user to autofile", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(statusResponseNoRecord),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({ autofilePlanned: true, paymentMethod: PaymentMethod.DIRECT_DEPOSIT }),
+        }) as unknown as typeof fetch;
+
+      renderLandingPage();
+      await fillAndSubmitForm();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/autofile",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(mockPush).toHaveBeenCalledWith("/anchor-autofile");
+      expect(logGAEvent).toHaveBeenCalledWith(`autofile_${PaymentMethod.DIRECT_DEPOSIT}`);
+    });
+
+    it("it calls autofile API, when autofile record is NOT found, it shows the application not found alert", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(statusResponseNoRecord),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ autofilePlanned: false }),
+        }) as unknown as typeof fetch;
+
+      renderLandingPage();
+      await fillAndSubmitForm();
+
+      expect(
+        screen.getByRole("heading", { name: "No 2025 application found" }),
+      ).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(logGAEvent).toHaveBeenCalledWith("api_200_record_not_found");
+    });
+
+    it("it calls autofile API, when response is not 200, it shows the error message", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(statusResponseNoRecord),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({}),
+        }) as unknown as typeof fetch;
+
+      renderLandingPage();
+      await fillAndSubmitForm();
+
+      expect(
+        screen.getByText(/We are having an issue checking on your application status/i),
+      ).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(logGAEvent).toHaveBeenCalledWith("autofile_api_error");
+    });
+  });
+});
+
+describe("determineRoute", () => {
+  it("routes a user to payment info when record has PTR payment sent", () => {
+    const record = buildStatusRecord({
+      ptr: [{ status: TransactionStatus.PAYMENT_SENT }],
+    });
+
+    expect(determineRoute(record)).toBe("/payment-info");
+  });
+
+  it("routes a user to more-information-needed when record has a flagged issue", () => {
+    const record = buildStatusRecord({
+      ptr: [{ status: TransactionStatus.ISSUE_FLAGGED, review_category: "SVR" }],
+      anchor: [{ status: TransactionStatus.ISSUE_FLAGGED, review_category: "MOD" }],
+    });
+
+    expect(determineRoute(record)).toBe("/more-information-needed");
+  });
+
+  it("routes a user to the application received page when no PTR payment sent and no issue is flagged", () => {
+    const record = buildStatusRecord({
+      ptr: [{ status: TransactionStatus.PROCESSING }],
+    });
+
+    expect(determineRoute(record)).toBe("/application-received");
+  });
+});

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -33,7 +33,11 @@ interface AutofileResponse {
   readonly paymentMethod?: PaymentMethod;
 }
 
-const checkAutofile = async (params: {
+interface StatusResponse {
+  readonly records: StatusRecord[];
+}
+
+const callAutofileApi = async (params: {
   readonly ssn: string;
   readonly zip: string;
 }): Promise<AutofileResponse | null> => {
@@ -52,6 +56,28 @@ const checkAutofile = async (params: {
     return (await response.json()) as AutofileResponse;
   } catch {
     logGAEvent(`autofile_api_error`);
+    return null;
+  }
+};
+
+const callStatusApi = async (params: {
+  readonly ssn: string;
+  readonly zip: string;
+}): Promise<StatusResponse | null> => {
+  try {
+    const response = await fetch("/api/status", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ssn: params.ssn, zip: params.zip }),
+    });
+
+    if (!response.ok) {
+      logGAEvent(`api_error`);
+      return null;
+    }
+    return (await response.json()) as StatusResponse;
+  } catch {
+    logGAEvent(`api_error`);
     return null;
   }
 };
@@ -99,80 +125,70 @@ const LandingPage = () => {
     setAlertContent(null);
 
     try {
-      const autofileResult = await checkAutofile({ ssn: data.ssn, zip: data.zipCode });
-
-      if (autofileResult?.autofilePlanned) {
-        setDataStore({
-          type: DataType.AUTOFILE,
-          lastFourSsnDigits: maskSsn(data.ssn),
-          zipCode: data.zipCode,
-          paymentMethod: autofileResult.paymentMethod,
-        });
-        logGAEvent(`autofile_${autofileResult.paymentMethod}`);
-        router.push("/anchor-autofile");
-        return;
-      }
-
-      const response = await fetch("/api/status", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ssn: data.ssn, zip: data.zipCode }),
-      });
-
-      if (!response.ok) {
+      const statusResult = await callStatusApi({ ssn: data.ssn, zip: data.zipCode });
+      if (statusResult === null) {
         setAlertContent(
           <p className="usa-alert__text maxw-tablet">
             We are having an issue checking on your application status. Please try again later.
           </p>,
         );
-        logGAEvent(`api_error`);
         returnToTop();
         return;
       }
 
-      const body = (await response.json()) as {
-        records: readonly StatusRecord[];
-      };
-
-      const record2025 = body.records.find((r) => r.return_year === "2025");
+      const record2025 = statusResult.records.find((r) => r.return_year === "2025");
 
       if (!record2025) {
-        setAlertContent(
-          <>
-            <h2 className="usa-alert__heading">No 2025 application found</h2>
-            <p className="usa-alert__text">
-              We couldn't find any records matching the SSN or ITIN and ZIP code you entered. Some
-              common reasons why:
-            </p>
-            <ul>
-              <li>
-                <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your
-                application is different than the one you just entered.
-              </li>
-              <li>
-                <strong>It's too soon</strong>: For online applications, it can take up to three
-                weeks for an application to show up on this website. For paper applications, it can
-                take up to 12 weeks. For ANCHOR-only applicants, check back in the fall of 2026.
-              </li>
-            </ul>
-            <p className="usa-alert__text">
-              Find the{" "}
-              <a
-                href="#faq_no_2025_application_found"
-                onClick={(e) => {
-                  e.preventDefault();
-                  expandFaqAccordionItem("faq_no_2025_application_found");
-                }}
-              >
-                full list of other possible reasons
-              </a>{" "}
-              your application is not showing up
-            </p>
-          </>,
-        );
-        logGAEvent(`api_200_record_not_found`);
-        returnToTop();
-        return;
+        const autofileResult = await callAutofileApi({ ssn: data.ssn, zip: data.zipCode });
+        if (autofileResult?.autofilePlanned) {
+          setDataStore({
+            type: DataType.AUTOFILE,
+            lastFourSsnDigits: maskSsn(data.ssn),
+            zipCode: data.zipCode,
+            paymentMethod: autofileResult.paymentMethod,
+          });
+          logGAEvent(`autofile_${autofileResult.paymentMethod}`);
+          router.push("/anchor-autofile");
+          return;
+        } else {
+          setAlertContent(
+            <>
+              <h2 className="usa-alert__heading">No 2025 application found</h2>
+              <p className="usa-alert__text">
+                We couldn't find any records matching the SSN or ITIN and ZIP code you entered. Some
+                common reasons why:
+              </p>
+              <ul>
+                <li>
+                  <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your
+                  application is different than the one you just entered.
+                </li>
+                <li>
+                  <strong>It's too soon</strong>: For online applications, it can take up to three
+                  weeks for an application to show up on this website. For paper applications, it
+                  can take up to 12 weeks. For ANCHOR-only applicants, check back in the fall of
+                  2026.
+                </li>
+              </ul>
+              <p className="usa-alert__text">
+                Find the{" "}
+                <a
+                  href="#faq_no_2025_application_found"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    expandFaqAccordionItem("faq_no_2025_application_found");
+                  }}
+                >
+                  full list of other possible reasons
+                </a>{" "}
+                your application is not showing up
+              </p>
+            </>,
+          );
+          logGAEvent(`api_200_record_not_found`);
+          returnToTop();
+          return;
+        }
       }
 
       const lastFourSsnDigits = maskSsn(data.ssn);

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -40,46 +40,37 @@ interface StatusResponse {
 const callAutofileApi = async (params: {
   readonly ssn: string;
   readonly zip: string;
-}): Promise<AutofileResponse | null> => {
-  try {
-    const response = await fetch("/api/autofile", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ssn: params.ssn, zip: params.zip }),
-    });
+}): Promise<AutofileResponse> => {
+  const response = await fetch("/api/autofile", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ssn: params.ssn, zip: params.zip }),
+  });
 
-    if (!response.ok) {
-      logGAEvent(`autofile_api_error`);
-      return null;
-    }
-
-    return (await response.json()) as AutofileResponse;
-  } catch {
+  if (!response.ok) {
     logGAEvent(`autofile_api_error`);
-    return null;
+    throw new Error(`Autofile API responded with status ${response.status}`);
   }
+
+  return (await response.json()) as AutofileResponse;
 };
 
 const callStatusApi = async (params: {
   readonly ssn: string;
   readonly zip: string;
-}): Promise<StatusResponse | null> => {
-  try {
-    const response = await fetch("/api/status", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ssn: params.ssn, zip: params.zip }),
-    });
+}): Promise<StatusResponse> => {
+  const response = await fetch("/api/status", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ssn: params.ssn, zip: params.zip }),
+  });
 
-    if (!response.ok) {
-      logGAEvent(`api_error`);
-      return null;
-    }
-    return (await response.json()) as StatusResponse;
-  } catch {
+  if (!response.ok) {
     logGAEvent(`api_error`);
-    return null;
+    throw new Error(`Status API responded with status ${response.status}`);
   }
+
+  return (await response.json()) as StatusResponse;
 };
 
 const determineRoute = (record: StatusRecord): string => {
@@ -121,98 +112,100 @@ const LandingPage = () => {
     shouldFocusError: false,
   });
 
+  const handleStatusApiError = () => {
+    setAlertContent(
+      <p className="usa-alert__text maxw-tablet">
+        We are having an issue checking on your application status. Please try again later.
+      </p>,
+    );
+    logGAEvent(`api_error`);
+    returnToTop();
+  };
+
+  const handleNoRecord = async (data: UserData) => {
+    const autofileResult = await callAutofileApi({ ssn: data.ssn, zip: data.zipCode });
+    if (autofileResult?.autofilePlanned) {
+      setDataStore({
+        type: DataType.AUTOFILE,
+        lastFourSsnDigits: maskSsn(data.ssn),
+        zipCode: data.zipCode,
+        paymentMethod: autofileResult.paymentMethod,
+      });
+      logGAEvent(`autofile_${autofileResult.paymentMethod}`);
+      router.push("/anchor-autofile");
+      return;
+    } else {
+      setAlertContent(
+        <>
+          <h2 className="usa-alert__heading">No 2025 application found</h2>
+          <p className="usa-alert__text">
+            We couldn't find any records matching the SSN or ITIN and ZIP code you entered. Some
+            common reasons why:
+          </p>
+          <ul>
+            <li>
+              <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your
+              application is different than the one you just entered.
+            </li>
+            <li>
+              <strong>It's too soon</strong>: For online applications, it can take up to three weeks
+              for an application to show up on this website. For paper applications, it can take up
+              to 12 weeks. For ANCHOR-only applicants, check back in the fall of 2026.
+            </li>
+          </ul>
+          <p className="usa-alert__text">
+            Find the{" "}
+            <a
+              href="#faq_no_2025_application_found"
+              onClick={(e) => {
+                e.preventDefault();
+                expandFaqAccordionItem("faq_no_2025_application_found");
+              }}
+            >
+              full list of other possible reasons
+            </a>{" "}
+            your application is not showing up
+          </p>
+        </>,
+      );
+      logGAEvent(`api_200_record_not_found`);
+      returnToTop();
+      return;
+    }
+  };
+
+  const handleRecordFound = (record: StatusRecord, data: UserData) => {
+    const lastFourSsnDigits = maskSsn(data.ssn);
+    const formattedDate = formatDate(record.application_date);
+    setDataStore({
+      type: DataType.STATUS,
+      lastFourSsnDigits: lastFourSsnDigits,
+      zipCode: data.zipCode,
+      applicationDateString: formattedDate,
+      anchor: record.anchor,
+      ptr: record.ptr,
+      stay_nj: record.stay_nj,
+      issueFlagged: setIssueFlagged(record),
+    });
+    logGAEvent(`api_200_record_found`);
+    router.push(determineRoute(record));
+  };
+
   const onSubmit: SubmitHandler<UserData> = async (data) => {
     setAlertContent(null);
 
     try {
       const statusResult = await callStatusApi({ ssn: data.ssn, zip: data.zipCode });
-      if (statusResult === null) {
-        setAlertContent(
-          <p className="usa-alert__text maxw-tablet">
-            We are having an issue checking on your application status. Please try again later.
-          </p>,
-        );
-        returnToTop();
-        return;
-      }
-
       const record2025 = statusResult.records.find((r) => r.return_year === "2025");
 
       if (!record2025) {
-        const autofileResult = await callAutofileApi({ ssn: data.ssn, zip: data.zipCode });
-        if (autofileResult?.autofilePlanned) {
-          setDataStore({
-            type: DataType.AUTOFILE,
-            lastFourSsnDigits: maskSsn(data.ssn),
-            zipCode: data.zipCode,
-            paymentMethod: autofileResult.paymentMethod,
-          });
-          logGAEvent(`autofile_${autofileResult.paymentMethod}`);
-          router.push("/anchor-autofile");
-          return;
-        } else {
-          setAlertContent(
-            <>
-              <h2 className="usa-alert__heading">No 2025 application found</h2>
-              <p className="usa-alert__text">
-                We couldn't find any records matching the SSN or ITIN and ZIP code you entered. Some
-                common reasons why:
-              </p>
-              <ul>
-                <li>
-                  <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your
-                  application is different than the one you just entered.
-                </li>
-                <li>
-                  <strong>It's too soon</strong>: For online applications, it can take up to three
-                  weeks for an application to show up on this website. For paper applications, it
-                  can take up to 12 weeks. For ANCHOR-only applicants, check back in the fall of
-                  2026.
-                </li>
-              </ul>
-              <p className="usa-alert__text">
-                Find the{" "}
-                <a
-                  href="#faq_no_2025_application_found"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    expandFaqAccordionItem("faq_no_2025_application_found");
-                  }}
-                >
-                  full list of other possible reasons
-                </a>{" "}
-                your application is not showing up
-              </p>
-            </>,
-          );
-          logGAEvent(`api_200_record_not_found`);
-          returnToTop();
-          return;
-        }
+        await handleNoRecord(data);
+        return;
       }
 
-      const lastFourSsnDigits = maskSsn(data.ssn);
-      const formattedDate = formatDate(record2025.application_date);
-      setDataStore({
-        type: DataType.STATUS,
-        lastFourSsnDigits: lastFourSsnDigits,
-        zipCode: data.zipCode,
-        applicationDateString: formattedDate,
-        anchor: record2025.anchor,
-        ptr: record2025.ptr,
-        stay_nj: record2025.stay_nj,
-        issueFlagged: setIssueFlagged(record2025),
-      });
-      logGAEvent(`api_200_record_found`);
-      router.push(determineRoute(record2025));
+      handleRecordFound(record2025, data);
     } catch {
-      setAlertContent(
-        <p className="usa-alert__text maxw-tablet">
-          We are having an issue checking on your application status. Please try again later.
-        </p>,
-      );
-      logGAEvent(`api_error`);
-      returnToTop();
+      handleStatusApiError();
     }
   };
 

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -95,6 +95,40 @@ const returnToTop = () => {
   topOfPage.scrollIntoView({ behavior: "smooth", block: "start" });
 };
 
+const NoApplicationFoundAlert = () => (
+  <>
+    <h2 className="usa-alert__heading">No 2025 application found</h2>
+    <p className="usa-alert__text">
+      We couldn't find any records matching the SSN or ITIN and ZIP code you entered. Some common
+      reasons why:
+    </p>
+    <ul>
+      <li>
+        <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your application is
+        different than the one you just entered.
+      </li>
+      <li>
+        <strong>It's too soon</strong>: For online applications, it can take up to three weeks for
+        an application to show up on this website. For paper applications, it can take up to 12
+        weeks. For ANCHOR-only applicants, check back in the fall of 2026.
+      </li>
+    </ul>
+    <p className="usa-alert__text">
+      Find the{" "}
+      <a
+        href="#faq_no_2025_application_found"
+        onClick={(e) => {
+          e.preventDefault();
+          expandFaqAccordionItem("faq_no_2025_application_found");
+        }}
+      >
+        full list of other possible reasons
+      </a>{" "}
+      your application is not showing up
+    </p>
+  </>
+);
+
 const LandingPage = () => {
   const router = useRouter();
   const { setDataStore } = useDataStore();
@@ -135,39 +169,7 @@ const LandingPage = () => {
       router.push("/anchor-autofile");
       return;
     } else {
-      setAlertContent(
-        <>
-          <h2 className="usa-alert__heading">No 2025 application found</h2>
-          <p className="usa-alert__text">
-            We couldn't find any records matching the SSN or ITIN and ZIP code you entered. Some
-            common reasons why:
-          </p>
-          <ul>
-            <li>
-              <strong>Identity mismatch</strong>: The SSN/ITIN and ZIP code filed on your
-              application is different than the one you just entered.
-            </li>
-            <li>
-              <strong>It's too soon</strong>: For online applications, it can take up to three weeks
-              for an application to show up on this website. For paper applications, it can take up
-              to 12 weeks. For ANCHOR-only applicants, check back in the fall of 2026.
-            </li>
-          </ul>
-          <p className="usa-alert__text">
-            Find the{" "}
-            <a
-              href="#faq_no_2025_application_found"
-              onClick={(e) => {
-                e.preventDefault();
-                expandFaqAccordionItem("faq_no_2025_application_found");
-              }}
-            >
-              full list of other possible reasons
-            </a>{" "}
-            your application is not showing up
-          </p>
-        </>,
-      );
+      setAlertContent(<NoApplicationFoundAlert />);
       logGAEvent(`api_200_record_not_found`);
       returnToTop();
       return;

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -73,7 +73,7 @@ const callStatusApi = async (params: {
   return (await response.json()) as StatusResponse;
 };
 
-const determineRoute = (record: StatusRecord): string => {
+export const determineRoute = (record: StatusRecord): string => {
   const hasPaymentSentTransaction = [...record.ptr].some(
     (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
   );
@@ -152,7 +152,6 @@ const LandingPage = () => {
         We are having an issue checking on your application status. Please try again later.
       </p>,
     );
-    logGAEvent(`api_error`);
     returnToTop();
   };
 

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -13,19 +13,12 @@ import { formatDate } from "@/app/utils/formatDate";
 import { logGAEvent } from "./utils/analytics";
 import { DataType, useDataStore } from "@/components/TaxReliefDataProvider";
 import { setIssueFlagged } from "./utils/setIssueFlagged";
-import { PaymentMethod, Transaction, TransactionStatus } from "@/components/types";
+import type { PaymentMethod, StatusRecord } from "@/components/types";
+import { determineRoute } from "./utils/determineRoute";
 
 interface UserData {
   readonly ssn: string;
   readonly zipCode: string;
-}
-
-export interface StatusRecord {
-  readonly return_year: string;
-  readonly application_date: string;
-  readonly anchor: Transaction[];
-  readonly ptr: Transaction[];
-  readonly stay_nj: Transaction[];
 }
 
 interface AutofileResponse {
@@ -71,22 +64,6 @@ const callStatusApi = async (params: {
   }
 
   return (await response.json()) as StatusResponse;
-};
-
-export const determineRoute = (record: StatusRecord): string => {
-  const hasPaymentSentTransaction = [...record.ptr].some(
-    (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
-  );
-
-  if (hasPaymentSentTransaction) {
-    return "/payment-info";
-  }
-
-  if (setIssueFlagged(record) !== undefined) {
-    return "/more-information-needed";
-  }
-
-  return "/application-received";
 };
 
 const returnToTop = () => {

--- a/webapp/app/utils/determineRoute.test.ts
+++ b/webapp/app/utils/determineRoute.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { determineRoute } from "./determineRoute";
+import type { StatusRecord } from "@/components/types";
+import { TransactionStatus } from "@/components/types";
+
+const buildStatusRecord = (overrides?: Partial<StatusRecord>): StatusRecord => ({
+  return_year: "2025",
+  application_date: "2026-03-19T00:00:00.000Z",
+  anchor: [],
+  ptr: [],
+  stay_nj: [],
+  ...overrides,
+});
+
+describe("determineRoute", () => {
+  it("routes a user to payment info when record has PTR payment sent", () => {
+    const record = buildStatusRecord({
+      ptr: [{ status: TransactionStatus.PAYMENT_SENT }],
+    });
+
+    expect(determineRoute(record)).toBe("/payment-info");
+  });
+
+  it("routes a user to more-information-needed when record has a flagged issue", () => {
+    const record = buildStatusRecord({
+      ptr: [{ status: TransactionStatus.ISSUE_FLAGGED, review_category: "SVR" }],
+      anchor: [{ status: TransactionStatus.ISSUE_FLAGGED, review_category: "MOD" }],
+    });
+
+    expect(determineRoute(record)).toBe("/more-information-needed");
+  });
+
+  it("routes a user to the application received page when no PTR payment sent and no issue is flagged", () => {
+    const record = buildStatusRecord({
+      ptr: [{ status: TransactionStatus.PROCESSING }],
+    });
+
+    expect(determineRoute(record)).toBe("/application-received");
+  });
+});

--- a/webapp/app/utils/determineRoute.ts
+++ b/webapp/app/utils/determineRoute.ts
@@ -1,0 +1,20 @@
+import { TransactionStatus } from "@/components/types";
+import type { StatusRecord } from "@/components/types";
+import { setIssueFlagged } from "./setIssueFlagged";
+
+/** Determines the route to navigate to based on the status record's transaction data. */
+export const determineRoute = (record: StatusRecord): string => {
+  const hasPaymentSentTransaction = [...record.ptr].some(
+    (transaction) => transaction.status === TransactionStatus.PAYMENT_SENT,
+  );
+
+  if (hasPaymentSentTransaction) {
+    return "/payment-info";
+  }
+
+  if (setIssueFlagged(record) !== undefined) {
+    return "/more-information-needed";
+  }
+
+  return "/application-received";
+};

--- a/webapp/app/utils/setIssueFlagged.test.ts
+++ b/webapp/app/utils/setIssueFlagged.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 
-import type { StatusRecord } from "../page";
 import { setIssueFlagged } from "./setIssueFlagged";
-import { TransactionStatus, Transaction, IssueFlaggedType } from "@/components/types";
+import type { StatusRecord, Transaction } from "@/components/types";
+import { TransactionStatus, IssueFlaggedType } from "@/components/types";
 
 const buildRecord = (overrides: Partial<StatusRecord> = {}): StatusRecord => ({
   return_year: "2024",

--- a/webapp/app/utils/setIssueFlagged.ts
+++ b/webapp/app/utils/setIssueFlagged.ts
@@ -1,5 +1,5 @@
 import { IssueFlaggedType, Transaction, TransactionStatus } from "@/components/types";
-import { StatusRecord } from "../page";
+import type { StatusRecord } from "@/components/types";
 
 const ISSUE_FLAGGED_TAX_BILL_NEEDED_REVIEW_CATEGORIES = ["MOD", "MDZ"];
 const ISSUE_FLAGGED_CONTACT_TAXATION_REVIEW_CATEGORIES = ["MAX", "MHX", "PCT", "DSU", "DSO"];

--- a/webapp/components/types.ts
+++ b/webapp/components/types.ts
@@ -43,3 +43,11 @@ export enum IssueFlaggedType {
   PROPERTY_TAX_BILL_NEEDED,
   CONTACT_TAXATION,
 }
+
+export interface StatusRecord {
+  readonly return_year: string;
+  readonly application_date: string;
+  readonly anchor: Transaction[];
+  readonly ptr: Transaction[];
+  readonly stay_nj: Transaction[];
+}

--- a/webapp/cypress/e2e/applicationReceived.cy.ts
+++ b/webapp/cypress/e2e/applicationReceived.cy.ts
@@ -35,10 +35,6 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
-  cy.intercept("POST", "/api/autofile", {
-    statusCode: 200,
-    fixture: "autofile_api_not_planned.json",
-  });
   fillFields();
 });
 

--- a/webapp/cypress/e2e/autofile.cy.ts
+++ b/webapp/cypress/e2e/autofile.cy.ts
@@ -9,10 +9,26 @@ beforeEach(() => {
   });
   cy.visit("/");
   fillFields();
+  cy.intercept("POST", "/api/status", {
+    statusCode: 200,
+    fixture: "v2_api_empty_records.json",
+  });
+});
+
+it("should route the user to the payment-info page when autofile API and status API return records", () => {
+  cy.intercept("POST", "/api/status", {
+    statusCode: 200,
+    fixture: "v2_api_found_records.json",
+  });
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_check.json",
+  });
+  cy.contains("button", `Check Status`).click();
+  cy.url().should("include", "/payment-info");
 });
 
 it("should route the user to the autofile page when autofile API returns true with CHECK", () => {
-  fillFields();
   cy.intercept("POST", "/api/autofile", {
     statusCode: 200,
     fixture: "autofile_api_check.json",
@@ -47,7 +63,6 @@ it("should route the user to the autofile page when autofile API returns true wi
 });
 
 it("should route the user to the autofile page when autofile API returns true with Direct Deposit", () => {
-  fillFields();
   cy.intercept("POST", "/api/autofile", {
     statusCode: 200,
     fixture: "autofile_api_direct_deposit.json",

--- a/webapp/cypress/e2e/landingPage.cy.ts
+++ b/webapp/cypress/e2e/landingPage.cy.ts
@@ -6,10 +6,6 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
-  cy.intercept("POST", "/api/autofile", {
-    statusCode: 200,
-    fixture: "autofile_api_not_planned.json",
-  });
 });
 
 it("should allow the user to visit the webpage", () => {

--- a/webapp/cypress/e2e/landingPage.cy.ts
+++ b/webapp/cypress/e2e/landingPage.cy.ts
@@ -106,6 +106,10 @@ it("should display api alert if records is empty in a 200 response", () => {
     statusCode: 200,
     fixture: "v2_api_empty_records.json",
   });
+  cy.intercept("POST", "/api/autofile", {
+    statusCode: 200,
+    fixture: "autofile_api_not_planned.json",
+  });
   cy.contains("button", `Check Status`).click();
   cy.contains("h2", "No 2025 application found").should("be.visible");
   cy.get("@gtag").should(

--- a/webapp/cypress/e2e/moreInformationNeeded.cy.ts
+++ b/webapp/cypress/e2e/moreInformationNeeded.cy.ts
@@ -26,10 +26,6 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
-  cy.intercept("POST", "/api/autofile", {
-    statusCode: 200,
-    fixture: "autofile_api_not_planned.json",
-  });
 });
 
 it("should display issue flagged warning - upload tax bill", () => {

--- a/webapp/cypress/e2e/paymentInfo.cy.ts
+++ b/webapp/cypress/e2e/paymentInfo.cy.ts
@@ -57,10 +57,6 @@ beforeEach(() => {
     win.gtag = cy.stub().as("gtag");
   });
   cy.visit("/");
-  cy.intercept("POST", "/api/autofile", {
-    statusCode: 200,
-    fixture: "autofile_api_not_planned.json",
-  });
   fillFields();
 });
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "5.2.0",
     "@aws-sdk/credential-provider-node": "3.972.81",
-    "@smithy/signature-v4": "5.7.3",
     "@newjersey/njwds": "2.9.2",
     "@smithy/protocol-http": "5.6.2",
+    "@smithy/signature-v4": "5.7.3",
     "@testing-library/jest-dom": "7.0.1",
     "@trussworks/react-uswds": "12.0.0",
     "next": "16.3.3",
@@ -38,9 +38,10 @@
   },
   "devDependencies": {
     "@testing-library/react": "16.3.3",
+    "@testing-library/user-event": "14.6.7",
     "@types/node": "25.9.5",
+    "cypress": "15.21.1",
     "jsdom": "30.0.1",
-    "vitest": "4.1.11",
-    "cypress": "15.21.1"
+    "vitest": "4.1.11"
   }
 }


### PR DESCRIPTION
## Link to ticket

This commit resolves #286 

## LLM Disclaimer

- An LLM helped with generating ideas for refactoring `onSubmit` to be more legible
- I wrote the unit test cases, an LLM filled them in, and then I worked to remove redundant mocks and change testing approach (e.g. the determine route tests used to be done by filling the form, but now they test the function directly)

## What was done?
- Previously, we called the `autofile` API first, and used `status` API as a fallback if no record was found
- This PR changes the ordering. Now, `status` API will the be first call, and `autofile` will only be called if no record is found.
- Refactored `onSubmit` handler to be more readable
- added unit tests for landing page
- moved StatusRecord to shared types
- refactor to break out determineRoute into its own module

## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## Steps to test
- Mock out both calls to return `record found` using browser tools, and verify that they are routed to the correct page rather than the `autofile` page.

## Screenshots (for visual changes)
Not a visual change

## Notes
- May be helpful to switch to a split diff in the GH review, at least for the updated `onSubmit` logic