### PR TITLE
update API to return form_code

### DIFF
--- a/lambda/src/helpers.ts
+++ b/lambda/src/helpers.ts
@@ -13,5 +13,6 @@ export const buildMockRow = (overrides = {}) => ({
   CHECK_1_AMT: 1750,
   CHECK_1_NUM: "922775385",
   TRANS_1_TAX_CDE: 13,
+  FORM_CDE: "PAS1W",
   ...overrides,
 });

--- a/lambda/src/index.test.ts
+++ b/lambda/src/index.test.ts
@@ -155,11 +155,44 @@ describe("handler business logic", () => {
       expect(body["records"]).toHaveLength(1);
       expect(body["records"][0].return_year).toBe("2025");
       expect(body["records"][0].application_date).toBe("10/31/2025 00:00:00");
+      expect(body["records"][0].form_code).toBe("PAS-1");
       expect(body["records"][0]["anchor"][0].status).toBe("payment_sent");
       expect(body["records"][0].ptr).toBeDefined();
       expect(body["records"][0].ptr.length).toBe(0);
       expect(body["records"][0].stay_nj).toBeDefined();
       expect(body["records"][0].stay_nj.length).toBe(0);
     });
+  });
+});
+
+describe("form code logic", () => {
+  const test_form_code = async (dbFormCode: string | null, expectedFormCode: string | null) => {
+    const row = buildMockRow({ FORM_CDE: dbFormCode });
+    mockExecute.mockResolvedValue({ rows: [row] });
+    const result = await handler({ ssn: "123456789", zip: "12345" });
+    const body = JSON.parse(result.body);
+    expect(body["records"][0].form_code).toBe(expectedFormCode);
+  };
+
+  it("handles null form code", async () => {
+    await test_form_code(null, null);
+  });
+  it("handles PAS1W form code", async () => {
+    await test_form_code("PAS1W", "PAS-1");
+  });
+  it("handles PAS1D form code", async () => {
+    await test_form_code("PAS1D", "PAS-1");
+  });
+  it("handles PAS1P form code", async () => {
+    await test_form_code("PAS1P", "PAS-1");
+  });
+  it("handles ANC1W form code", async () => {
+    await test_form_code("ANC1W", "ANC-1");
+  });
+  it("handles ANC1D form code", async () => {
+    await test_form_code("ANC1D", "ANC-1");
+  });
+  it("handles ANC1P form code", async () => {
+    await test_form_code("ANC1P", "ANC-1");
   });
 });

--- a/lambda/src/index.test.ts
+++ b/lambda/src/index.test.ts
@@ -177,6 +177,9 @@ describe("form code logic", () => {
   it("handles null form code", async () => {
     await test_form_code(null, null);
   });
+  it("handles unknown form code", async () => {
+    await test_form_code("unknown", null);
+  });
   it("handles PAS1W form code", async () => {
     await test_form_code("PAS1W", "PAS-1");
   });

--- a/lambda/src/index.ts
+++ b/lambda/src/index.ts
@@ -29,9 +29,16 @@ interface ValidationResult {
   readonly zip?: string;
 }
 
+/** The form filed by the taxpayer for property tax relief */
+enum FormCode {
+  ANC1 = "ANC-1",
+  PAS1 = "PAS-1",
+}
+
 interface ResponseRecord {
   readonly return_year: string;
   readonly application_date: string;
+  readonly form_code: FormCode | null;
   readonly anchor: Transaction[];
   readonly ptr: Transaction[];
   readonly stay_nj: Transaction[];
@@ -85,10 +92,31 @@ const mapRowToRecord = (row: InquiryRow): ResponseRecord => {
   return {
     return_year: String(row.RETURN_YEAR_DTE),
     application_date: row.RNY_APPLIED_DTE,
+    form_code: mapFormCode(row.FORM_CDE),
     anchor: allTransactions.anchor,
     ptr: allTransactions.ptr,
     stay_nj: allTransactions.stay_nj,
   };
+};
+
+const mapFormCode = (dbFormCode: string): FormCode | null => {
+  switch (dbFormCode) {
+    case "PAS1W":
+      return FormCode.PAS1;
+    case "PAS1D":
+      return FormCode.PAS1;
+    case "PAS1P":
+      return FormCode.PAS1;
+    case "ANC1W":
+      return FormCode.ANC1;
+    case "ANC1D":
+      return FormCode.ANC1;
+    case "ANC1P":
+      return FormCode.ANC1;
+    default:
+      console.log(`Unknown FORM_CDE: ${dbFormCode}`);
+      return null;
+  }
 };
 
 const buildResponse = (rows: InquiryRow[]): BuildResponseResult => {

--- a/lambda/src/types.d.ts
+++ b/lambda/src/types.d.ts
@@ -23,5 +23,6 @@ export interface InquiryRow {
   readonly RETURN_YEAR_DTE: number;
   readonly TRANS_TOTAL_NUM: number;
   readonly DLN_NUM: string;
+  readonly FORM_CDE: string;
   readonly [key: string]: unknown;
 }


### PR DESCRIPTION
## Link to ticket

This PR is the first step to resolving #256
The next PR will be an update to the webapp code to handle this new field.

## LLM Disclaimer

- An LLM was used to debug a type failure (root cause was that `enum` is executable code, and can't be in the `types.d.ts` file as esbuild won't read it). Resolution was manual, I moved the type into `index.ts`.

## What was done?

- We'd like to show users different content based on what their original filing form was
- Taxation has added a field to their DB that captures a taxpayer's original filing form
- This change updates the API to read this new field and include it in the API response

## Accessibility
N/A

## Steps to test

- `npm run test`
- This change has been deployed to our dev environment, connecting to the dev TAXU database, and we have verified that the behavior is correct by manually triggering the lambda with test cases.

## Screenshots (for visual changes)
None, this is an API change

## Notes
- Do reviewers feel like `form_code` in the response should be optional? Current API design expects the field to exist but allows it to be null when an unexpected value in the DB is encountered.